### PR TITLE
added queue group config for default queues (wait task), queue group in event handler

### DIFF
--- a/event-queue/nats-streaming/src/main/java/com/netflix/conductor/contribs/queue/stan/config/NATSStreamConfiguration.java
+++ b/event-queue/nats-streaming/src/main/java/com/netflix/conductor/contribs/queue/stan/config/NATSStreamConfiguration.java
@@ -58,7 +58,7 @@ public class NATSStreamConfiguration {
                             ? conductorProperties.getAppId() + "_nats_stream_notify_" + stack
                             : properties.getListenerQueuePrefix();
 
-            String queueName = queuePrefix + status.name();
+            String queueName = queuePrefix + status.name() + getQueueGroup(properties);
 
             ObservableQueue queue =
                     new NATSStreamObservableQueue(
@@ -71,5 +71,12 @@ public class NATSStreamConfiguration {
         }
 
         return queues;
+    }
+
+    private String getQueueGroup(final NATSStreamProperties properties) {
+        if (properties.getDefaultQueueGroup() == null || properties.getDefaultQueueGroup().isBlank()) {
+            return "";
+        }
+        return ":" + properties.getDefaultQueueGroup();
     }
 }

--- a/event-queue/nats-streaming/src/main/java/com/netflix/conductor/contribs/queue/stan/config/NATSStreamProperties.java
+++ b/event-queue/nats-streaming/src/main/java/com/netflix/conductor/contribs/queue/stan/config/NATSStreamProperties.java
@@ -30,6 +30,9 @@ public class NATSStreamProperties {
     /** The prefix to be used for the default listener queues */
     private String listenerQueuePrefix = "";
 
+    /** WAIT tasks default queue group, to make subscription round-robin delivery to single sub */
+    private String defaultQueueGroup = "wait-group";
+
     public String getClusterId() {
         return clusterId;
     }
@@ -60,5 +63,13 @@ public class NATSStreamProperties {
 
     public void setListenerQueuePrefix(String listenerQueuePrefix) {
         this.listenerQueuePrefix = listenerQueuePrefix;
+    }
+
+    public String getDefaultQueueGroup() {
+        return defaultQueueGroup;
+    }
+
+    public void setDefaultQueueGroup(String defaultQueueGroup) {
+        this.defaultQueueGroup = defaultQueueGroup;
     }
 }

--- a/event-queue/nats/src/main/java/com/netflix/conductor/contribs/queue/nats/JetStreamObservableQueue.java
+++ b/event-queue/nats/src/main/java/com/netflix/conductor/contribs/queue/nats/JetStreamObservableQueue.java
@@ -53,18 +53,30 @@ public class JetStreamObservableQueue implements ObservableQueue {
     private final Lock mu = new ReentrantLock();
     private final String queueType;
     private final String subject;
+    private final String queueUri;
     private final JetStreamProperties properties;
     private final Scheduler scheduler;
     private final AtomicBoolean running = new AtomicBoolean(false);
     private Connection nc;
     private JetStreamSubscription sub;
     private Observable<Long> interval;
+    private final String queueGroup;
 
     public JetStreamObservableQueue(
-            JetStreamProperties properties, String queueType, String subject, Scheduler scheduler) {
-        LOG.debug("JSM obs queue create, qtype={}, quri={}", queueType, subject);
+            JetStreamProperties properties, String queueType, String queueUri, Scheduler scheduler) {
+        LOG.debug("JSM obs queue create, qtype={}, quri={}", queueType, queueUri);
+
+        this.queueUri = queueUri;
+        // If queue specified (e.g. subject:queue) - split to subject & queue
+        if (queueUri.contains(":")) {
+            this.subject = queueUri.substring(0, queueUri.indexOf(':'));
+            queueGroup = queueUri.substring(queueUri.indexOf(':') + 1);
+        } else {
+            this.subject = queueUri;
+            queueGroup = null;
+        }
+
         this.queueType = queueType;
-        this.subject = subject;
         this.properties = properties;
         this.scheduler = scheduler;
     }
@@ -188,7 +200,7 @@ public class JetStreamObservableQueue implements ObservableQueue {
         if (running.get()) {
             return;
         }
-        LOG.info("Starting JSM observable, name={}", subject);
+        LOG.info("Starting JSM observable, name={}", queueUri);
         try {
             Nats.connectAsynchronously(
                     new Options.Builder()
@@ -249,7 +261,7 @@ public class JetStreamObservableQueue implements ObservableQueue {
             sub =
                     js.subscribe(
                             subject,
-                            properties.getDurableName(),
+                            queueGroup,
                             nc.createDispatcher(),
                             msg -> {
                                 var message = new JsmMessage();
@@ -258,7 +270,7 @@ public class JetStreamObservableQueue implements ObservableQueue {
                                 message.setPayload(new String(msg.getData()));
                                 messages.add(message);
                             },
-                            false,
+                            /*autoAck*/ false,
                             pso);
             LOG.debug("Subscribed successfully {}", sub.getConsumerInfo());
             this.running.set(true);

--- a/event-queue/nats/src/main/java/com/netflix/conductor/contribs/queue/nats/JetStreamObservableQueue.java
+++ b/event-queue/nats/src/main/java/com/netflix/conductor/contribs/queue/nats/JetStreamObservableQueue.java
@@ -123,7 +123,7 @@ public class JetStreamObservableQueue implements ObservableQueue {
 
     @Override
     public String getName() {
-        return subject;
+        return queueUri;
     }
 
     @Override

--- a/event-queue/nats/src/main/java/com/netflix/conductor/contribs/queue/nats/config/JetStreamConfiguration.java
+++ b/event-queue/nats/src/main/java/com/netflix/conductor/contribs/queue/nats/config/JetStreamConfiguration.java
@@ -59,12 +59,19 @@ public class JetStreamConfiguration {
                             ? conductorProperties.getAppId() + "_jsm_notify_" + stack
                             : properties.getListenerQueuePrefix();
 
-            String queueName = queuePrefix + status.name();
+            String queueName = queuePrefix + status.name() + getQueueGroup(properties);
 
             ObservableQueue queue = provider.getQueue(queueName);
             queues.put(status, queue);
         }
 
         return queues;
+    }
+
+    private String getQueueGroup(final JetStreamProperties properties) {
+        if (properties.getDefaultQueueGroup() == null || properties.getDefaultQueueGroup().isBlank()) {
+            return "";
+        }
+        return ":" + properties.getDefaultQueueGroup();
     }
 }

--- a/event-queue/nats/src/main/java/com/netflix/conductor/contribs/queue/nats/config/JetStreamProperties.java
+++ b/event-queue/nats/src/main/java/com/netflix/conductor/contribs/queue/nats/config/JetStreamProperties.java
@@ -32,6 +32,9 @@ public class JetStreamProperties {
 
     private Duration pollTimeDuration = Duration.ofMillis(100);
 
+    /** WAIT tasks default queue group, to make subscription round-robin delivery to single sub */
+    private String defaultQueueGroup = "wait-group";
+
     public Duration getPollTimeDuration() {
         return pollTimeDuration;
     }
@@ -70,5 +73,13 @@ public class JetStreamProperties {
 
     public void setStreamStorageType(String streamStorageType) {
         this.streamStorageType = streamStorageType;
+    }
+
+    public String getDefaultQueueGroup() {
+        return defaultQueueGroup;
+    }
+
+    public void setDefaultQueueGroup(String defaultQueueGroup) {
+        this.defaultQueueGroup = defaultQueueGroup;
     }
 }


### PR DESCRIPTION
NATS has queue groups feature which allows round-robin send messages to subscriptions. This PR adds queue group name into configuration for WAIT task queues.

For Nats JetStream specify queue group (the same way as for Nats Streaming) in event handler definition as
```
"event": "jsm:copy_payment_info_fail_event_stream:group"
```
see `:group` it can be any allowed group name.

Pull Request type
----

- [x] Feature