### PR TITLE
bugfix: add default message for user if the data in Postgres EPS

### DIFF
--- a/external-payload-storage/postgres-external-storage/src/main/java/com/netflix/conductor/postgres/config/PostgresPayloadConfiguration.java
+++ b/external-payload-storage/postgres-external-storage/src/main/java/com/netflix/conductor/postgres/config/PostgresPayloadConfiguration.java
@@ -33,6 +33,8 @@ import com.netflix.conductor.postgres.storage.PostgresPayloadStorage;
 public class PostgresPayloadConfiguration {
 
     PostgresPayloadProperties properties;
+    private static final String DEFAULT_MESSAGE_TO_USER =
+            "{\"Error\": \"Data with this ID does not exist or has been deleted from the external storage.\"}";
 
     public PostgresPayloadConfiguration(PostgresPayloadProperties properties) {
         this.properties = properties;
@@ -78,6 +80,7 @@ public class PostgresPayloadConfiguration {
                         .username(properties.getUsername())
                         .password(properties.getPassword())
                         .build();
-        return new PostgresPayloadStorage(idGenerator, properties, dataSource);
+        return new PostgresPayloadStorage(
+                idGenerator, properties, dataSource, DEFAULT_MESSAGE_TO_USER);
     }
 }


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

Adds default message for user if the data in PostgreSQL External Payload Storage doesn't exist.

Alternatives considered
----

_Describe alternative implementation you have considered_