### PR TITLE
Update Core to 3.13.3 and update ES7 changes

### DIFF
--- a/community-server/dependencies.lock
+++ b/community-server/dependencies.lock
@@ -9,34 +9,34 @@
             "project": true
         },
         "com.netflix.conductor:conductor-awss3-storage": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-awssqs-event-queue": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-azureblob-storage": {
             "project": true
         },
         "com.netflix.conductor:conductor-cassandra-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common-persistence": {
             "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-es6-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-grpc-server": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-http-task": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-json-jq-task": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-kafka": {
             "project": true
@@ -57,16 +57,16 @@
             "project": true
         },
         "com.netflix.conductor:conductor-redis-concurrency-limit": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-redis-lock": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-redis-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-rest": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-workflow-event-listener": {
             "project": true
@@ -90,7 +90,7 @@
             "locked": "2.17.1"
         },
         "org.springdoc:springdoc-openapi-ui": {
-            "locked": "1.6.12"
+            "locked": "1.6.14"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "2.6.7"
@@ -149,16 +149,16 @@
             "project": true
         },
         "com.netflix.conductor:conductor-awss3-storage": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-awssqs-event-queue": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-azureblob-storage": {
             "project": true
         },
         "com.netflix.conductor:conductor-cassandra-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -173,7 +173,7 @@
                 "com.netflix.conductor:conductor-postgres-persistence",
                 "com.netflix.conductor:conductor-workflow-event-listener"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common-persistence": {
             "firstLevelTransitive": [
@@ -196,19 +196,19 @@
                 "com.netflix.conductor:conductor-workflow-event-listener",
                 "com.netflix.conductor:conductor-zookeeper-lock"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-es6-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-grpc-server": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-http-task": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-json-jq-task": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-kafka": {
             "project": true
@@ -229,16 +229,16 @@
             "project": true
         },
         "com.netflix.conductor:conductor-redis-concurrency-limit": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-redis-lock": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-redis-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-rest": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-workflow-event-listener": {
             "project": true
@@ -438,7 +438,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-postgres-external-storage"
             ],
-            "locked": "1.6.12"
+            "locked": "1.6.14"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "2.6.7"
@@ -505,16 +505,16 @@
             "project": true
         },
         "com.netflix.conductor:conductor-awss3-storage": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-awssqs-event-queue": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-azureblob-storage": {
             "project": true
         },
         "com.netflix.conductor:conductor-cassandra-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -529,7 +529,7 @@
                 "com.netflix.conductor:conductor-postgres-persistence",
                 "com.netflix.conductor:conductor-workflow-event-listener"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common-persistence": {
             "firstLevelTransitive": [
@@ -552,19 +552,19 @@
                 "com.netflix.conductor:conductor-workflow-event-listener",
                 "com.netflix.conductor:conductor-zookeeper-lock"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-es6-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-grpc-server": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-http-task": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-json-jq-task": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-kafka": {
             "project": true
@@ -585,16 +585,16 @@
             "project": true
         },
         "com.netflix.conductor:conductor-redis-concurrency-limit": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-redis-lock": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-redis-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-rest": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-workflow-event-listener": {
             "project": true
@@ -794,7 +794,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-postgres-external-storage"
             ],
-            "locked": "1.6.12"
+            "locked": "1.6.14"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "2.6.7"
@@ -831,37 +831,37 @@
             "project": true
         },
         "com.netflix.conductor:conductor-awss3-storage": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-awssqs-event-queue": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-azureblob-storage": {
             "project": true
         },
         "com.netflix.conductor:conductor-cassandra-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common-persistence": {
             "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-es6-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-grpc-server": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-http-task": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-json-jq-task": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-kafka": {
             "project": true
@@ -882,16 +882,16 @@
             "project": true
         },
         "com.netflix.conductor:conductor-redis-concurrency-limit": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-redis-lock": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-redis-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-rest": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-workflow-event-listener": {
             "project": true
@@ -927,7 +927,7 @@
             "locked": "5.8.2"
         },
         "org.springdoc:springdoc-openapi-ui": {
-            "locked": "1.6.12"
+            "locked": "1.6.14"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "2.6.7"
@@ -992,16 +992,16 @@
             "project": true
         },
         "com.netflix.conductor:conductor-awss3-storage": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-awssqs-event-queue": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-azureblob-storage": {
             "project": true
         },
         "com.netflix.conductor:conductor-cassandra-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -1016,7 +1016,7 @@
                 "com.netflix.conductor:conductor-postgres-persistence",
                 "com.netflix.conductor:conductor-workflow-event-listener"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common-persistence": {
             "firstLevelTransitive": [
@@ -1039,19 +1039,19 @@
                 "com.netflix.conductor:conductor-workflow-event-listener",
                 "com.netflix.conductor:conductor-zookeeper-lock"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-es6-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-grpc-server": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-http-task": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-json-jq-task": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-kafka": {
             "project": true
@@ -1072,16 +1072,16 @@
             "project": true
         },
         "com.netflix.conductor:conductor-redis-concurrency-limit": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-redis-lock": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-redis-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-rest": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-workflow-event-listener": {
             "project": true
@@ -1108,10 +1108,10 @@
             "locked": "5.13.1"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.50.0"
+            "locked": "1.50.2"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.50.0"
+            "locked": "1.50.2"
         },
         "io.grpc:grpc-testing": {
             "locked": "1.33.1"
@@ -1293,7 +1293,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-postgres-external-storage"
             ],
-            "locked": "1.6.12"
+            "locked": "1.6.14"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "2.6.7"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@
  * Common place to define all the version dependencies
  */
 ext {
-    revConductor = '3.13.2'
+    revConductor = '3.13.3'
     revActivation = '2.0.0'
     revAmqpClient = '5.13.0'
     revAwaitility = '3.1.6'

--- a/event-queue/amqp/dependencies.lock
+++ b/event-queue/amqp/dependencies.lock
@@ -9,10 +9,10 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.rabbitmq:amqp-client": {
             "locked": "5.13.0"
@@ -50,10 +50,10 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.rabbitmq:amqp-client": {
             "locked": "5.13.0"
@@ -85,10 +85,10 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.rabbitmq:amqp-client": {
             "locked": "5.13.0"
@@ -129,10 +129,10 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.rabbitmq:amqp-client": {
             "locked": "5.13.0"

--- a/event-queue/nats-streaming/dependencies.lock
+++ b/event-queue/nats-streaming/dependencies.lock
@@ -9,10 +9,10 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "io.nats:java-nats-streaming": {
             "locked": "2.2.3"
@@ -53,10 +53,10 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "io.nats:java-nats-streaming": {
             "locked": "2.2.3"
@@ -91,10 +91,10 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "io.nats:java-nats-streaming": {
             "locked": "2.2.3"
@@ -138,10 +138,10 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "io.nats:java-nats-streaming": {
             "locked": "2.2.3"

--- a/event-queue/nats-streaming/src/main/java/com/netflix/conductor/contribs/queue/stan/config/NATSStreamConfiguration.java
+++ b/event-queue/nats-streaming/src/main/java/com/netflix/conductor/contribs/queue/stan/config/NATSStreamConfiguration.java
@@ -74,7 +74,8 @@ public class NATSStreamConfiguration {
     }
 
     private String getQueueGroup(final NATSStreamProperties properties) {
-        if (properties.getDefaultQueueGroup() == null || properties.getDefaultQueueGroup().isBlank()) {
+        if (properties.getDefaultQueueGroup() == null
+                || properties.getDefaultQueueGroup().isBlank()) {
             return "";
         }
         return ":" + properties.getDefaultQueueGroup();

--- a/event-queue/nats/dependencies.lock
+++ b/event-queue/nats/dependencies.lock
@@ -9,10 +9,10 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "io.nats:jnats": {
             "locked": "2.15.6"
@@ -50,10 +50,10 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "io.nats:jnats": {
             "locked": "2.15.6"
@@ -85,10 +85,10 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "io.nats:jnats": {
             "locked": "2.15.6"
@@ -129,10 +129,10 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "io.nats:jnats": {
             "locked": "2.15.6"

--- a/event-queue/nats/src/main/java/com/netflix/conductor/contribs/queue/nats/JetStreamObservableQueue.java
+++ b/event-queue/nats/src/main/java/com/netflix/conductor/contribs/queue/nats/JetStreamObservableQueue.java
@@ -63,7 +63,10 @@ public class JetStreamObservableQueue implements ObservableQueue {
     private final String queueGroup;
 
     public JetStreamObservableQueue(
-            JetStreamProperties properties, String queueType, String queueUri, Scheduler scheduler) {
+            JetStreamProperties properties,
+            String queueType,
+            String queueUri,
+            Scheduler scheduler) {
         LOG.debug("JSM obs queue create, qtype={}, quri={}", queueType, queueUri);
 
         this.queueUri = queueUri;

--- a/event-queue/nats/src/main/java/com/netflix/conductor/contribs/queue/nats/config/JetStreamConfiguration.java
+++ b/event-queue/nats/src/main/java/com/netflix/conductor/contribs/queue/nats/config/JetStreamConfiguration.java
@@ -69,7 +69,8 @@ public class JetStreamConfiguration {
     }
 
     private String getQueueGroup(final JetStreamProperties properties) {
-        if (properties.getDefaultQueueGroup() == null || properties.getDefaultQueueGroup().isBlank()) {
+        if (properties.getDefaultQueueGroup() == null
+                || properties.getDefaultQueueGroup().isBlank()) {
             return "";
         }
         return ":" + properties.getDefaultQueueGroup();

--- a/external-payload-storage/azureblob-storage/dependencies.lock
+++ b/external-payload-storage/azureblob-storage/dependencies.lock
@@ -9,10 +9,10 @@
             "locked": "12.7.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
@@ -41,10 +41,10 @@
             "locked": "12.7.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
@@ -70,10 +70,10 @@
             "locked": "12.7.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
@@ -108,10 +108,10 @@
             "locked": "12.7.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"

--- a/external-payload-storage/postgres-external-storage/dependencies.lock
+++ b/external-payload-storage/postgres-external-storage/dependencies.lock
@@ -6,10 +6,10 @@
     },
     "compileClasspath": {
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.17.1"
@@ -33,7 +33,7 @@
             "locked": "42.3.4"
         },
         "org.springdoc:springdoc-openapi-ui": {
-            "locked": "1.6.12"
+            "locked": "1.6.14"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "2.6.7"
@@ -47,10 +47,10 @@
     },
     "runtimeClasspath": {
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.17.1"
@@ -74,7 +74,7 @@
             "locked": "42.3.4"
         },
         "org.springdoc:springdoc-openapi-ui": {
-            "locked": "1.6.12"
+            "locked": "1.6.14"
         },
         "org.springframework.boot:spring-boot-starter-jdbc": {
             "locked": "2.6.7"
@@ -82,10 +82,10 @@
     },
     "testCompileClasspath": {
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.17.1"
@@ -112,7 +112,7 @@
             "locked": "42.3.4"
         },
         "org.springdoc:springdoc-openapi-ui": {
-            "locked": "1.6.12"
+            "locked": "1.6.14"
         },
         "org.springframework.boot:spring-boot-starter-jdbc": {
             "locked": "2.6.7"
@@ -132,10 +132,10 @@
     },
     "testRuntimeClasspath": {
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.17.1"
@@ -162,7 +162,7 @@
             "locked": "42.3.4"
         },
         "org.springdoc:springdoc-openapi-ui": {
-            "locked": "1.6.12"
+            "locked": "1.6.14"
         },
         "org.springframework.boot:spring-boot-starter-jdbc": {
             "locked": "2.6.7"

--- a/index/es7-persistence/dependencies.lock
+++ b/index/es7-persistence/dependencies.lock
@@ -15,13 +15,13 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common-persistence": {
             "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "commons-io:commons-io": {
             "locked": "2.7"
@@ -77,7 +77,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common-persistence"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common-persistence": {
             "project": true
@@ -86,7 +86,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common-persistence"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "commons-io:commons-io": {
             "locked": "2.7"
@@ -153,13 +153,13 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common-persistence": {
             "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "commons-io:commons-io": {
             "locked": "2.7"
@@ -238,7 +238,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common-persistence"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common-persistence": {
             "project": true
@@ -247,7 +247,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common-persistence"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "commons-io:commons-io": {
             "locked": "2.7"

--- a/index/es7-persistence/src/main/java/com/netflix/conductor/es7/dao/index/ElasticSearchRestDAOV7.java
+++ b/index/es7-persistence/src/main/java/com/netflix/conductor/es7/dao/index/ElasticSearchRestDAOV7.java
@@ -25,6 +25,7 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.entity.ContentType;
@@ -878,6 +879,94 @@ public class ElasticSearchRestDAOV7 extends ElasticSearchBaseDAO implements Inde
             logger.error("Failed to update workflow {}", workflowInstanceId, e);
             Monitors.error(className, "update");
         }
+    }
+
+    @Override
+    public void removeTask(String workflowId, String taskId) {
+        long startTime = Instant.now().toEpochMilli();
+
+        SearchResult<String> taskSearchResult =
+                searchTasks(
+                        String.format("(taskId='%s') AND (workflowId='%s')", taskId, workflowId),
+                        "*",
+                        0,
+                        1,
+                        null);
+
+        if (taskSearchResult.getTotalHits() == 0) {
+            logger.error("Task: {} does not belong to workflow: {}", taskId, workflowId);
+            Monitors.error(className, "removeTask");
+            return;
+        }
+
+        DeleteRequest request = new DeleteRequest(taskIndexName, taskId);
+
+        try {
+            DeleteResponse response = elasticSearchClient.delete(request, RequestOptions.DEFAULT);
+
+            if (response.getResult() != DocWriteResponse.Result.DELETED) {
+                logger.error("Index removal failed - task not found by id: {}", workflowId);
+                Monitors.error(className, "removeTask");
+                return;
+            }
+            long endTime = Instant.now().toEpochMilli();
+            logger.debug(
+                    "Time taken {} for removing task:{} of workflow: {}",
+                    endTime - startTime,
+                    taskId,
+                    workflowId);
+            Monitors.recordESIndexTime("remove_task", "", endTime - startTime);
+            Monitors.recordWorkerQueueSize(
+                    "indexQueue", ((ThreadPoolExecutor) executorService).getQueue().size());
+        } catch (IOException e) {
+            logger.error(
+                    "Failed to remove task {} of workflow: {} from index", taskId, workflowId, e);
+            Monitors.error(className, "removeTask");
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> asyncRemoveTask(String workflowId, String taskId) {
+        return CompletableFuture.runAsync(() -> removeTask(workflowId, taskId), executorService);
+    }
+
+    @Override
+    public void updateTask(String workflowId, String taskId, String[] keys, Object[] values) {
+        try {
+            if (keys.length != values.length) {
+                throw new IllegalArgumentException("Number of keys and values do not match");
+            }
+
+            long startTime = Instant.now().toEpochMilli();
+            UpdateRequest request = new UpdateRequest(taskIndexName, taskId);
+            Map<String, Object> source =
+                    IntStream.range(0, keys.length)
+                            .boxed()
+                            .collect(Collectors.toMap(i -> keys[i], i -> values[i]));
+            request.doc(source);
+
+            logger.debug("Updating task: {} of workflow: {} with {}", taskId, workflowId, source);
+            elasticSearchClient.update(request, RequestOptions.DEFAULT);
+            long endTime = Instant.now().toEpochMilli();
+            logger.debug(
+                    "Time taken {} for updating task: {} of workflow: {}",
+                    endTime - startTime,
+                    taskId,
+                    workflowId);
+            Monitors.recordESIndexTime("update_task", "", endTime - startTime);
+            Monitors.recordWorkerQueueSize(
+                    "indexQueue", ((ThreadPoolExecutor) executorService).getQueue().size());
+        } catch (Exception e) {
+            logger.error("Failed to update task: {} of workflow: {}", taskId, workflowId, e);
+            Monitors.error(className, "update");
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> asyncUpdateTask(
+            String workflowId, String taskId, String[] keys, Object[] values) {
+        return CompletableFuture.runAsync(
+                () -> updateTask(workflowId, taskId, keys, values), executorService);
     }
 
     @Override

--- a/index/es7-persistence/src/main/java/com/netflix/conductor/es7/dao/index/ElasticSearchRestDAOV7.java
+++ b/index/es7-persistence/src/main/java/com/netflix/conductor/es7/dao/index/ElasticSearchRestDAOV7.java
@@ -25,7 +25,6 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.entity.ContentType;

--- a/index/es7-persistence/src/test/java/com/netflix/conductor/es7/dao/index/TestElasticSearchRestDAOV7.java
+++ b/index/es7-persistence/src/test/java/com/netflix/conductor/es7/dao/index/TestElasticSearchRestDAOV7.java
@@ -31,6 +31,7 @@ import com.netflix.conductor.es7.utils.TestUtils;
 import com.google.common.collect.ImmutableMap;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class TestElasticSearchRestDAOV7 extends ElasticSearchRestDaoBaseTest {
@@ -188,6 +189,84 @@ public class TestElasticSearchRestDAOV7 extends ElasticSearchRestDaoBaseTest {
         List<String> tasks = tryFindResults(() -> searchTasks(taskSummary));
 
         assertEquals(taskSummary.getTaskId(), tasks.get(0));
+    }
+
+    @Test
+    public void shouldRemoveTask() {
+        WorkflowSummary workflowSummary =
+                TestUtils.loadWorkflowSnapshot(objectMapper, "workflow_summary");
+        indexDAO.indexWorkflow(workflowSummary);
+
+        // wait for workflow to be indexed
+        tryFindResults(() -> searchWorkflows(workflowSummary.getWorkflowId()), 1);
+
+        TaskSummary taskSummary =
+                TestUtils.loadTaskSnapshot(
+                        objectMapper, "task_summary", workflowSummary.getWorkflowId());
+        indexDAO.indexTask(taskSummary);
+
+        // Wait for the task to be indexed
+        List<String> tasks = tryFindResults(() -> searchTasks(taskSummary), 1);
+
+        indexDAO.removeTask(workflowSummary.getWorkflowId(), taskSummary.getTaskId());
+
+        tasks = tryFindResults(() -> searchTasks(taskSummary), 0);
+
+        assertTrue("Task was not removed.", tasks.isEmpty());
+    }
+
+    @Test
+    public void shouldAsyncRemoveTask() throws Exception {
+        WorkflowSummary workflowSummary =
+                TestUtils.loadWorkflowSnapshot(objectMapper, "workflow_summary");
+        indexDAO.indexWorkflow(workflowSummary);
+
+        // wait for workflow to be indexed
+        tryFindResults(() -> searchWorkflows(workflowSummary.getWorkflowId()), 1);
+
+        TaskSummary taskSummary =
+                TestUtils.loadTaskSnapshot(
+                        objectMapper, "task_summary", workflowSummary.getWorkflowId());
+        indexDAO.indexTask(taskSummary);
+
+        // Wait for the task to be indexed
+        List<String> tasks = tryFindResults(() -> searchTasks(taskSummary), 1);
+
+        indexDAO.asyncRemoveTask(workflowSummary.getWorkflowId(), taskSummary.getTaskId()).get();
+
+        tasks = tryFindResults(() -> searchTasks(taskSummary), 0);
+
+        assertTrue("Task was not removed.", tasks.isEmpty());
+    }
+
+    @Test
+    public void shouldNotRemoveTaskWhenNotAssociatedWithWorkflow() {
+        TaskSummary taskSummary = TestUtils.loadTaskSnapshot(objectMapper, "task_summary");
+        indexDAO.indexTask(taskSummary);
+
+        // Wait for the task to be indexed
+        List<String> tasks = tryFindResults(() -> searchTasks(taskSummary), 1);
+
+        indexDAO.removeTask("InvalidWorkflow", taskSummary.getTaskId());
+
+        tasks = tryFindResults(() -> searchTasks(taskSummary), 0);
+
+        assertFalse("Task was removed.", tasks.isEmpty());
+    }
+
+    @Test
+    public void shouldNotAsyncRemoveTaskWhenNotAssociatedWithWorkflow() throws Exception {
+        TaskSummary taskSummary = TestUtils.loadTaskSnapshot(objectMapper, "task_summary");
+        indexDAO.indexTask(taskSummary);
+
+        // Wait for the task to be indexed
+        List<String> tasks = tryFindResults(() -> searchTasks(taskSummary), 1);
+
+        indexDAO.asyncRemoveTask("InvalidWorkflow", taskSummary.getTaskId()).get();
+
+        tasks = tryFindResults(() -> searchTasks(taskSummary), 0);
+
+        assertFalse("Task was removed.", tasks.isEmpty());
     }
 
     @Test

--- a/index/es7-persistence/src/test/java/com/netflix/conductor/es7/utils/TestUtils.java
+++ b/index/es7-persistence/src/test/java/com/netflix/conductor/es7/utils/TestUtils.java
@@ -50,6 +50,18 @@ public class TestUtils {
         }
     }
 
+    public static TaskSummary loadTaskSnapshot(
+            ObjectMapper objectMapper, String resourceFileName, String workflowId) {
+        try {
+            String content = loadJsonResource(resourceFileName);
+            content = content.replace(WORKFLOW_INSTANCE_ID_PLACEHOLDER, workflowId);
+
+            return objectMapper.readValue(content, TaskSummary.class);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
     public static String loadJsonResource(String resourceFileName) {
         try {
             return Resources.toString(

--- a/lock/zookeeper-lock/dependencies.lock
+++ b/lock/zookeeper-lock/dependencies.lock
@@ -6,7 +6,7 @@
     },
     "compileClasspath": {
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
@@ -35,7 +35,7 @@
     },
     "runtimeClasspath": {
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
@@ -61,7 +61,7 @@
     },
     "testCompileClasspath": {
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
@@ -99,7 +99,7 @@
     },
     "testRuntimeClasspath": {
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"

--- a/metrics/dependencies.lock
+++ b/metrics/dependencies.lock
@@ -9,10 +9,10 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.spectator:spectator-reg-metrics3": {
             "locked": "0.122.0"
@@ -65,10 +65,10 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.spectator:spectator-reg-metrics3": {
             "locked": "0.122.0"
@@ -115,10 +115,10 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.spectator:spectator-reg-metrics3": {
             "locked": "0.122.0"
@@ -183,10 +183,10 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.spectator:spectator-reg-metrics3": {
             "locked": "0.122.0"

--- a/persistence/common-persistence/dependencies.lock
+++ b/persistence/common-persistence/dependencies.lock
@@ -12,10 +12,10 @@
             "locked": "2.13.2.1"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
@@ -44,10 +44,10 @@
             "locked": "2.13.2.1"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
@@ -76,10 +76,10 @@
             "locked": "2.13.2.1"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
@@ -117,10 +117,10 @@
             "locked": "2.13.2.1"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"

--- a/persistence/mysql-persistence/dependencies.lock
+++ b/persistence/mysql-persistence/dependencies.lock
@@ -15,13 +15,13 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common-persistence": {
             "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "mysql:mysql-connector-java": {
             "locked": "8.0.28"
@@ -77,7 +77,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common-persistence"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common-persistence": {
             "project": true
@@ -86,7 +86,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common-persistence"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "mysql:mysql-connector-java": {
             "locked": "8.0.28"
@@ -145,25 +145,25 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-client": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common-persistence": {
             "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-es6-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-grpc-client": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-server": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "mysql:mysql-connector-java": {
             "locked": "8.0.28"
@@ -240,13 +240,13 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-client": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common-persistence"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common-persistence": {
             "project": true
@@ -255,16 +255,16 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common-persistence"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-es6-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-grpc-client": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-server": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "mysql:mysql-connector-java": {
             "locked": "8.0.28"

--- a/persistence/postgres-persistence/dependencies.lock
+++ b/persistence/postgres-persistence/dependencies.lock
@@ -15,13 +15,13 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common-persistence": {
             "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
@@ -77,7 +77,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common-persistence"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common-persistence": {
             "project": true
@@ -86,7 +86,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common-persistence"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -145,25 +145,25 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-client": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common-persistence": {
             "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-es6-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-grpc-client": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-server": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
@@ -240,13 +240,13 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-client": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common-persistence"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common-persistence": {
             "project": true
@@ -255,16 +255,16 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common-persistence"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-es6-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-grpc-client": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-server": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [

--- a/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresExecutionDAO.java
+++ b/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresExecutionDAO.java
@@ -17,9 +17,7 @@ import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -57,7 +55,9 @@ public class PostgresExecutionDAO extends PostgresBaseDAO
     public PostgresExecutionDAO(
             RetryTemplate retryTemplate, ObjectMapper objectMapper, DataSource dataSource) {
         super(retryTemplate, objectMapper, dataSource);
-        this.executor = Executors.newSingleThreadScheduledExecutor(runnable -> new Thread(THREAD_GROUP, runnable));
+        this.executor =
+                Executors.newSingleThreadScheduledExecutor(
+                        runnable -> new Thread(THREAD_GROUP, runnable));
     }
 
     private static String dateStr(Long timeInMs) {
@@ -317,18 +317,19 @@ public class PostgresExecutionDAO extends PostgresBaseDAO
         return removed;
     }
 
-    /**
-     * Scheduled executor based implementation.
-     */
+    /** Scheduled executor based implementation. */
     @Override
     public boolean removeWorkflowWithExpiry(String workflowId, int ttlSeconds) {
-        executor.schedule(() -> {
-            try {
-                removeWorkflow(workflowId);
-            } catch (Throwable e) {
-                logger.warn("Unable to remove workflow: {} with expiry", workflowId, e);
-            }
-        }, ttlSeconds, TimeUnit.SECONDS);
+        executor.schedule(
+                () -> {
+                    try {
+                        removeWorkflow(workflowId);
+                    } catch (Throwable e) {
+                        logger.warn("Unable to remove workflow: {} with expiry", workflowId, e);
+                    }
+                },
+                ttlSeconds,
+                TimeUnit.SECONDS);
 
         return true;
     }

--- a/persistence/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresExecutionDAOTest.java
+++ b/persistence/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresExecutionDAOTest.java
@@ -11,7 +11,6 @@
  */
 package com.netflix.conductor.postgres.dao;
 
-import com.google.common.collect.Iterables;
 import java.util.List;
 
 import org.flywaydb.core.Flyway;
@@ -31,6 +30,8 @@ import com.netflix.conductor.dao.ExecutionDAO;
 import com.netflix.conductor.dao.ExecutionDAOTest;
 import com.netflix.conductor.model.WorkflowModel;
 import com.netflix.conductor.postgres.config.PostgresConfiguration;
+
+import com.google.common.collect.Iterables;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/task/kafka/dependencies.lock
+++ b/task/kafka/dependencies.lock
@@ -9,10 +9,10 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.2"
@@ -59,10 +59,10 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.2"
@@ -97,10 +97,10 @@
             "locked": "30.0-jre"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-test-util": {
             "project": true
@@ -189,49 +189,49 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-test-util"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-test-util"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-test-util"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-grpc-client": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-test-util"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-grpc-server": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-test-util"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-redis-persistence": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-test-util"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-rest": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-test-util"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-server": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-test-util"
             ],
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-test-util": {
             "project": true

--- a/test-util/dependencies.lock
+++ b/test-util/dependencies.lock
@@ -18,28 +18,28 @@
             "locked": "3.13.0"
         },
         "com.netflix.conductor:conductor-client": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-grpc-client": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-grpc-server": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-redis-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-rest": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-server": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.dyno-queues:dyno-queues-redis": {
             "locked": "2.0.20"
@@ -110,28 +110,28 @@
             "locked": "3.13.0"
         },
         "com.netflix.conductor:conductor-client": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-grpc-client": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-grpc-server": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-redis-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-rest": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-server": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.dyno-queues:dyno-queues-redis": {
             "locked": "2.0.20"
@@ -202,28 +202,28 @@
             "locked": "3.13.0"
         },
         "com.netflix.conductor:conductor-client": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-grpc-client": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-grpc-server": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-redis-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-rest": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-server": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.dyno-queues:dyno-queues-redis": {
             "locked": "2.0.20"
@@ -306,28 +306,28 @@
             "locked": "3.13.0"
         },
         "com.netflix.conductor:conductor-client": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-grpc-client": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-grpc-server": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-redis-persistence": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-rest": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-server": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.dyno-queues:dyno-queues-redis": {
             "locked": "2.0.20"

--- a/workflow-event-listener/dependencies.lock
+++ b/workflow-event-listener/dependencies.lock
@@ -6,10 +6,10 @@
     },
     "compileClasspath": {
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.17.1"
@@ -35,10 +35,10 @@
     },
     "runtimeClasspath": {
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.17.1"
@@ -58,13 +58,13 @@
     },
     "testCompileClasspath": {
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-server": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.17.1"
@@ -105,13 +105,13 @@
     },
     "testRuntimeClasspath": {
         "com.netflix.conductor:conductor-common": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-core": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "com.netflix.conductor:conductor-server": {
-            "locked": "3.13.2"
+            "locked": "3.13.3"
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.17.1"

--- a/workflow-event-listener/src/test/java/com/netflix/conductor/test/listener/WorkflowStatusPublisherIntegrationTest.java
+++ b/workflow-event-listener/src/test/java/com/netflix/conductor/test/listener/WorkflowStatusPublisherIntegrationTest.java
@@ -19,8 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import com.netflix.conductor.common.metadata.workflow.StartWorkflowRequest;
-import com.netflix.conductor.service.WorkflowService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,17 +31,16 @@ import org.springframework.test.context.junit4.SpringRunner;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.tasks.TaskResult;
+import com.netflix.conductor.common.metadata.workflow.StartWorkflowRequest;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.common.run.WorkflowSummary;
 import com.netflix.conductor.core.events.queue.Message;
-import com.netflix.conductor.core.execution.StartWorkflowInput;
-import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.dao.QueueDAO;
-import com.netflix.conductor.model.WorkflowModel;
 import com.netflix.conductor.service.ExecutionService;
 import com.netflix.conductor.service.MetadataService;
+import com.netflix.conductor.service.WorkflowService;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -195,7 +192,8 @@ public class WorkflowStatusPublisherIntegrationTest {
     @SuppressWarnings("BusyWait")
     private void checkIfWorkflowIsCompleted(String id) throws InterruptedException {
         int statusRetrieveAttempts = 0;
-        while (workflowExecutor.getExecutionStatus(id, false).getStatus() != Workflow.WorkflowStatus.COMPLETED) {
+        while (workflowExecutor.getExecutionStatus(id, false).getStatus()
+                != Workflow.WorkflowStatus.COMPLETED) {
             if (statusRetrieveAttempts > 5) {
                 break;
             }


### PR DESCRIPTION
Pull Request type
----

- [X] Feature
- [X] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)

Changes in this PR
----
This syncs over changes that were made in Conductor Core 3.13.3 around ElasticSearch and the removing of tasks from the index instead of only workflows.