### PR TITLE
Add support for indexing to postgres persistence (Postgres indexDAO)

### DIFF
--- a/persistence/README.md
+++ b/persistence/README.md
@@ -27,7 +27,7 @@ Group: `com.netflix.conductor`
 ```properties
 conductor.db.type=mysql
 
-#Cache expiry for teh task definitions in seconds
+#Cache expiry for the task definitions in seconds
 conductor.mysql.taskDefCacheRefreshInterval=60
 
 #Use spring datasource properties to configure MySQL connection
@@ -45,8 +45,6 @@ spring.datasource.hikari.auto-commit=
 
 ```properties
 conductor.db.type=postgres
-#Cache expiry for teh task definitions in seconds
-conductor.mysql.taskDefCacheRefreshInterval=60
 
 #Use spring datasource properties to configure Postgres connection
 spring.datasource.url=
@@ -55,3 +53,30 @@ spring.datasource.password=
 spring.datasource.hikari.maximum-pool-size=
 spring.datasource.hikari.auto-commit=
 ```
+
+Additionally, the postgres module includes the ability to index your workflow and task executions and to store task execution logs in Postgres without requiring ElasticSearch.
+
+This can be enabled by setting the following in your application properties file:
+
+```properties
+conductor.indexing.type=postgres
+conductor.indexing.enabled=true
+# The following is to force Elastic Search IndexDAO not to run. If it just missing it will still try to start v6
+conductor.elasticsearch.version=postgres
+```
+
+It supports full querying of logs through the UI, and exposes the Postgres full text search in two ways. If you search for a chunk of JSON:
+
+```JSON
+{"workflowType":"my_workflow", "version": 3}
+```
+
+It will use an index to search for documents matching the values in the JSON. In this example, all JSON docs with a `workflowType` attribute set to `my_workflow` and a `version` attribute set to `3`.
+
+You can also use a full text search on the whole unstructured JSON document. This uses the Postgres [tsquery](https://www.postgresql.org/docs/11/datatype-textsearch.html#DATATYPE-TSQUERY) syntax for constructing searches. For example:
+
+```
+my-correlation-id & my-workflow
+```
+
+Will search for any document containing both `my-correlation-id` and `my-workflow`.

--- a/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
+++ b/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
@@ -22,16 +22,14 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.DependsOn;
-import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.*;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.backoff.NoBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
 import com.netflix.conductor.postgres.dao.PostgresExecutionDAO;
+import com.netflix.conductor.postgres.dao.PostgresIndexDAO;
 import com.netflix.conductor.postgres.dao.PostgresMetadataDAO;
 import com.netflix.conductor.postgres.dao.PostgresQueueDAO;
 
@@ -88,6 +86,15 @@ public class PostgresConfiguration {
             @Qualifier("postgresRetryTemplate") RetryTemplate retryTemplate,
             ObjectMapper objectMapper) {
         return new PostgresQueueDAO(retryTemplate, objectMapper, dataSource);
+    }
+
+    @Bean
+    @DependsOn({"flywayForPrimaryDb"})
+    @Conditional(PostgresIndexConditions.PostgresIndexingEnabled.class)
+    public PostgresIndexDAO postgresIndexDAO(
+            @Qualifier("postgresRetryTemplate") RetryTemplate retryTemplate,
+            ObjectMapper objectMapper) {
+        return new PostgresIndexDAO(retryTemplate, objectMapper, dataSource);
     }
 
     @Bean

--- a/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresIndexConditions.java
+++ b/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresIndexConditions.java
@@ -1,0 +1,41 @@
+/*
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.postgres.config;
+
+import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+public class PostgresIndexConditions {
+
+    private PostgresIndexConditions() {}
+
+    public static class PostgresIndexingEnabled extends AllNestedConditions {
+
+        PostgresIndexingEnabled() {
+            super(ConfigurationPhase.PARSE_CONFIGURATION);
+        }
+
+        @SuppressWarnings("unused")
+        @ConditionalOnProperty(
+                name = "conductor.indexing.enabled",
+                havingValue = "true",
+                matchIfMissing = true)
+        static class enabledIndexing {}
+
+        @SuppressWarnings("unused")
+        @ConditionalOnProperty(
+                name = "conductor.indexing.type",
+                havingValue = "postgres",
+                matchIfMissing = true)
+        static class enabledPostgresIndexing {}
+    }
+}

--- a/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresIndexDAO.java
+++ b/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresIndexDAO.java
@@ -1,0 +1,307 @@
+/*
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.postgres.dao;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+import javax.sql.DataSource;
+
+import org.springframework.retry.support.RetryTemplate;
+
+import com.netflix.conductor.common.metadata.events.EventExecution;
+import com.netflix.conductor.common.metadata.tasks.TaskExecLog;
+import com.netflix.conductor.common.run.SearchResult;
+import com.netflix.conductor.common.run.TaskSummary;
+import com.netflix.conductor.common.run.WorkflowSummary;
+import com.netflix.conductor.core.events.queue.Message;
+import com.netflix.conductor.dao.IndexDAO;
+import com.netflix.conductor.postgres.util.PostgresIndexQueryBuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class PostgresIndexDAO extends PostgresBaseDAO implements IndexDAO {
+
+    public PostgresIndexDAO(
+            RetryTemplate retryTemplate, ObjectMapper objectMapper, DataSource dataSource) {
+        super(retryTemplate, objectMapper, dataSource);
+    }
+
+    @Override
+    public void indexWorkflow(WorkflowSummary workflow) {
+        String INSERT_WORKFLOW_INDEX_SQL =
+                "INSERT INTO workflow_index (workflow_id, correlation_id, workflow_type, start_time, status, json_data)"
+                        + "VALUES (?, ?, ?, ?, ?, ?::JSONB) ON CONFLICT (workflow_id) \n"
+                        + "DO UPDATE SET correlation_id = EXCLUDED.correlation_id, workflow_type = EXCLUDED.workflow_type, "
+                        + "start_time = EXCLUDED.start_time, status = EXCLUDED.status, json_data = EXCLUDED.json_data";
+
+        TemporalAccessor ta = DateTimeFormatter.ISO_INSTANT.parse(workflow.getStartTime());
+        Timestamp startTime = Timestamp.from(Instant.from(ta));
+
+        queryWithTransaction(
+                INSERT_WORKFLOW_INDEX_SQL,
+                q ->
+                        q.addParameter(workflow.getWorkflowId())
+                                .addParameter(workflow.getCorrelationId())
+                                .addParameter(workflow.getWorkflowType())
+                                .addParameter(startTime)
+                                .addParameter(workflow.getStatus().toString())
+                                .addJsonParameter(workflow)
+                                .executeUpdate());
+    }
+
+    @Override
+    public SearchResult<WorkflowSummary> searchWorkflowSummary(
+            String query, String freeText, int start, int count, List<String> sort) {
+        PostgresIndexQueryBuilder queryBuilder =
+                new PostgresIndexQueryBuilder(
+                        "workflow_index", query, freeText, start, count, sort);
+
+        List<WorkflowSummary> results =
+                queryWithTransaction(
+                        queryBuilder.getQuery(),
+                        q -> {
+                            queryBuilder.addParameters(q);
+                            return q.executeAndFetch(WorkflowSummary.class);
+                        });
+
+        // To avoid making a second potentially expensive query to postgres say we've
+        // got enough results for another page so the pagination works
+        int totalHits = results.size() == count ? start + count + 1 : start + results.size();
+        return new SearchResult<>(totalHits, results);
+    }
+
+    @Override
+    public void indexTask(TaskSummary task) {
+        String INSERT_TASK_INDEX_SQL =
+                "INSERT INTO task_index (task_id, task_type, task_def_name, status, start_time, update_time, workflow_type, json_data)"
+                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?::JSONB) ON CONFLICT (task_id) "
+                        + "DO UPDATE SET task_type = EXCLUDED.task_type, task_def_name = EXCLUDED.task_def_name, "
+                        + "status = EXCLUDED.status, update_time = EXCLUDED.update_time, json_data = EXCLUDED.json_data";
+
+        TemporalAccessor updateTa = DateTimeFormatter.ISO_INSTANT.parse(task.getUpdateTime());
+        Timestamp updateTime = Timestamp.from(Instant.from(updateTa));
+
+        TemporalAccessor startTa = DateTimeFormatter.ISO_INSTANT.parse(task.getStartTime());
+        Timestamp startTime = Timestamp.from(Instant.from(startTa));
+
+        queryWithTransaction(
+                INSERT_TASK_INDEX_SQL,
+                q ->
+                        q.addParameter(task.getTaskId())
+                                .addParameter(task.getTaskType())
+                                .addParameter(task.getTaskDefName())
+                                .addParameter(task.getStatus().toString())
+                                .addParameter(startTime)
+                                .addParameter(updateTime)
+                                .addParameter(task.getWorkflowType())
+                                .addJsonParameter(task)
+                                .executeUpdate());
+    }
+
+    @Override
+    public SearchResult<TaskSummary> searchTaskSummary(
+            String query, String freeText, int start, int count, List<String> sort) {
+        PostgresIndexQueryBuilder queryBuilder =
+                new PostgresIndexQueryBuilder("task_index", query, freeText, start, count, sort);
+
+        List<TaskSummary> results =
+                queryWithTransaction(
+                        queryBuilder.getQuery(),
+                        q -> {
+                            queryBuilder.addParameters(q);
+                            return q.executeAndFetch(TaskSummary.class);
+                        });
+
+        // To avoid making a second potentially expensive query to postgres say we've
+        // got enough results for another page so the pagination works
+        int totalHits = results.size() == count ? start + count + 1 : start + results.size();
+        return new SearchResult<>(totalHits, results);
+    }
+
+    @Override
+    public void addTaskExecutionLogs(List<TaskExecLog> logs) {
+        String INSERT_LOG =
+                "INSERT INTO task_execution_logs (task_id, created_time, log) VALUES (?, ?, ?)";
+        for (TaskExecLog log : logs) {
+            queryWithTransaction(
+                    INSERT_LOG,
+                    q ->
+                            q.addParameter(log.getTaskId())
+                                    .addParameter(new Timestamp(log.getCreatedTime()))
+                                    .addParameter(log.getLog())
+                                    .executeUpdate());
+        }
+    }
+
+    @Override
+    public List<TaskExecLog> getTaskExecutionLogs(String taskId) {
+        return queryWithTransaction(
+                "SELECT log, task_id, created_time FROM task_execution_logs WHERE task_id = ? ORDER BY created_time ASC",
+                q ->
+                        q.addParameter(taskId)
+                                .executeAndFetch(
+                                        rs -> {
+                                            List<TaskExecLog> result = new ArrayList<>();
+                                            while (rs.next()) {
+                                                TaskExecLog log = new TaskExecLog();
+                                                log.setLog(rs.getString("log"));
+                                                log.setTaskId(rs.getString("task_id"));
+                                                log.setCreatedTime(
+                                                        rs.getDate("created_time").getTime());
+                                                result.add(log);
+                                            }
+                                            return result;
+                                        }));
+    }
+
+    @Override
+    public void setup() {}
+
+    @Override
+    public CompletableFuture<Void> asyncIndexWorkflow(WorkflowSummary workflow) {
+        throw new UnsupportedOperationException(
+                "asyncIndexWorkflow is not supported for postgres indexing");
+    }
+
+    @Override
+    public CompletableFuture<Void> asyncIndexTask(TaskSummary task) {
+        throw new UnsupportedOperationException(
+                "asyncIndexTask is not supported for postgres indexing");
+    }
+
+    @Override
+    public SearchResult<String> searchWorkflows(
+            String query, String freeText, int start, int count, List<String> sort) {
+        throw new UnsupportedOperationException(
+                "searchWorkflows is not supported for postgres indexing");
+    }
+
+    @Override
+    public SearchResult<String> searchTasks(
+            String query, String freeText, int start, int count, List<String> sort) {
+        throw new UnsupportedOperationException(
+                "searchTasks is not supported for postgres indexing");
+    }
+
+    @Override
+    public void removeWorkflow(String workflowId) {
+        throw new UnsupportedOperationException(
+                "removeWorkflow is not supported for postgres indexing");
+    }
+
+    @Override
+    public CompletableFuture<Void> asyncRemoveWorkflow(String workflowId) {
+        throw new UnsupportedOperationException(
+                "asyncRemoveWorkflow is not supported for postgres indexing");
+    }
+
+    @Override
+    public void updateWorkflow(String workflowInstanceId, String[] keys, Object[] values) {
+        throw new UnsupportedOperationException(
+                "updateWorkflow is not supported for postgres indexing");
+    }
+
+    @Override
+    public CompletableFuture<Void> asyncUpdateWorkflow(
+            String workflowInstanceId, String[] keys, Object[] values) {
+        throw new UnsupportedOperationException(
+                "asyncUpdateWorkflow is not supported for postgres indexing");
+    }
+
+    @Override
+    public void removeTask(String workflowId, String taskId) {
+        throw new UnsupportedOperationException(
+                "removeTask is not supported for postgres indexing");
+    }
+
+    @Override
+    public CompletableFuture<Void> asyncRemoveTask(String workflowId, String taskId) {
+        throw new UnsupportedOperationException(
+                "asyncRemoveTask is not supported for postgres indexing");
+    }
+
+    @Override
+    public void updateTask(String workflowId, String taskId, String[] keys, Object[] values) {
+        throw new UnsupportedOperationException(
+                "updateTask is not supported for postgres indexing");
+    }
+
+    @Override
+    public CompletableFuture<Void> asyncUpdateTask(
+            String workflowId, String taskId, String[] keys, Object[] values) {
+        throw new UnsupportedOperationException(
+                "asyncUpdateTask is not supported for postgres indexing");
+    }
+
+    @Override
+    public String get(String workflowInstanceId, String key) {
+        throw new UnsupportedOperationException("get is not supported for postgres indexing");
+    }
+
+    @Override
+    public CompletableFuture<Void> asyncAddTaskExecutionLogs(List<TaskExecLog> logs) {
+        throw new UnsupportedOperationException(
+                "asyncAddTaskExecutionLogs is not supported for postgres indexing");
+    }
+
+    @Override
+    public void addEventExecution(EventExecution eventExecution) {
+        throw new UnsupportedOperationException(
+                "addEventExecution is not supported for postgres indexing");
+    }
+
+    @Override
+    public List<EventExecution> getEventExecutions(String event) {
+        throw new UnsupportedOperationException(
+                "getEventExecutions is not supported for postgres indexing");
+    }
+
+    @Override
+    public CompletableFuture<Void> asyncAddEventExecution(EventExecution eventExecution) {
+        throw new UnsupportedOperationException(
+                "asyncAddEventExecution is not supported for postgres indexing");
+    }
+
+    @Override
+    public void addMessage(String queue, Message msg) {
+        throw new UnsupportedOperationException(
+                "addMessage is not supported for postgres indexing");
+    }
+
+    @Override
+    public CompletableFuture<Void> asyncAddMessage(String queue, Message message) {
+        throw new UnsupportedOperationException(
+                "asyncAddMessage is not supported for postgres indexing");
+    }
+
+    @Override
+    public List<Message> getMessages(String queue) {
+        throw new UnsupportedOperationException(
+                "getMessages is not supported for postgres indexing");
+    }
+
+    @Override
+    public List<String> searchArchivableWorkflows(String indexName, long archiveTtlDays) {
+        throw new UnsupportedOperationException(
+                "searchArchivableWorkflows is not supported for postgres indexing");
+    }
+
+    public long getWorkflowCount(String query, String freeText) {
+        throw new UnsupportedOperationException(
+                "getWorkflowCount is not supported for postgres indexing");
+    }
+}

--- a/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilder.java
+++ b/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilder.java
@@ -1,0 +1,220 @@
+/*
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.postgres.util;
+
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class PostgresIndexQueryBuilder {
+
+    private final String table;
+    private final String freeText;
+    private final int start;
+    private final int count;
+    private final List<String> sort;
+    private final List<Condition> conditions = new ArrayList<>();
+
+    private static final String[] VALID_FIELDS = {
+        "workflow_id",
+        "correlation_id",
+        "workflow_type",
+        "start_time",
+        "status",
+        "task_id",
+        "task_type",
+        "task_def_name",
+        "update_time",
+        "json_data",
+        "to_tsvector(json_data::text)"
+    };
+
+    private static final String[] VALID_SORT_ORDER = {"ASC", "DESC"};
+
+    private static class Condition {
+        private String attribute;
+        private String operator;
+        private List<String> values;
+        private final String CONDITION_REGEX = "([a-zA-Z]+)\\s?(=|>|<|IN)\\s?(.*)";
+
+        public Condition() {}
+
+        public Condition(String query) {
+            Pattern conditionRegex = Pattern.compile(CONDITION_REGEX);
+            Matcher conditionMatcher = conditionRegex.matcher(query);
+            if (conditionMatcher.find()) {
+                String[] valueArr = conditionMatcher.group(3).replaceAll("[\"()]", "").split(",");
+                ArrayList<String> values = new ArrayList<>(Arrays.asList(valueArr));
+                this.attribute = camelToSnake(conditionMatcher.group(1));
+                this.values = values;
+                this.operator = getOperator(conditionMatcher.group(2));
+                if (this.attribute.endsWith("_time")) {
+                    values.set(0, millisToUtc(values.get(0)));
+                }
+            }
+        }
+
+        public String getQueryFragment() {
+            if (operator.equals("IN")) {
+                return attribute + " = ANY(?)";
+            } else if (operator.equals("@@")) {
+                return attribute + " @@ to_tsquery(?)";
+            } else if (operator.equals("@>")) {
+                return attribute + " @> ?::JSONB";
+            } else {
+                if (attribute.endsWith("_time")) {
+                    return attribute + " " + operator + " ?::TIMESTAMPTZ";
+                } else {
+                    return attribute + " " + operator + " ?";
+                }
+            }
+        }
+
+        private String getOperator(String op) {
+            if (op.equals("IN") && values.size() == 1) {
+                return "=";
+            }
+            return op;
+        }
+
+        public void addParameter(Query q) throws SQLException {
+            if (values.size() > 1) {
+                q.addParameter(values);
+            } else {
+                q.addParameter(values.get(0));
+            }
+        }
+
+        private String millisToUtc(String millis) {
+            Long startTimeMilli = Long.parseLong(millis);
+            ZonedDateTime startDate =
+                    ZonedDateTime.ofInstant(Instant.ofEpochMilli(startTimeMilli), ZoneOffset.UTC);
+            return DateTimeFormatter.ISO_DATE_TIME.format(startDate);
+        }
+
+        private boolean isValid() {
+            return Arrays.asList(VALID_FIELDS).contains(attribute);
+        }
+
+        public void setAttribute(String attribute) {
+            this.attribute = attribute;
+        }
+
+        public void setOperator(String operator) {
+            this.operator = operator;
+        }
+
+        public void setValues(List<String> values) {
+            this.values = values;
+        }
+    }
+
+    public PostgresIndexQueryBuilder(
+            String table, String query, String freeText, int start, int count, List<String> sort) {
+        this.table = table;
+        this.freeText = freeText;
+        this.start = start;
+        this.count = count;
+        this.sort = sort;
+        this.parseQuery(query);
+        this.parseFreeText(freeText);
+    }
+
+    public String getQuery() {
+        String queryString = "";
+        List<Condition> validConditions =
+                conditions.stream().filter(c -> c.isValid()).collect(Collectors.toList());
+        if (validConditions.size() > 0) {
+            queryString =
+                    " WHERE "
+                            + String.join(
+                                    " AND ",
+                                    validConditions.stream()
+                                            .map(c -> c.getQueryFragment())
+                                            .collect(Collectors.toList()));
+        }
+        return "SELECT json_data::TEXT FROM "
+                + table
+                + queryString
+                + getSort()
+                + " LIMIT ? OFFSET ?";
+    }
+
+    public void addParameters(Query q) throws SQLException {
+        for (Condition condition : conditions) {
+            condition.addParameter(q);
+        }
+        q.addParameter(count);
+        q.addParameter(start);
+    }
+
+    private void parseQuery(String query) {
+        if (!StringUtils.isEmpty(query)) {
+            for (String s : query.split(" AND ")) {
+                conditions.add(new Condition(s));
+            }
+            Collections.sort(conditions, Comparator.comparing(Condition::getQueryFragment));
+        }
+    }
+
+    private void parseFreeText(String freeText) {
+        if (!StringUtils.isEmpty(freeText) && !freeText.equals("*")) {
+            if (freeText.startsWith("{") && freeText.endsWith("}")) {
+                Condition cond = new Condition();
+                cond.setAttribute("json_data");
+                cond.setOperator("@>");
+                String[] values = {freeText};
+                cond.setValues(Arrays.asList(values));
+                conditions.add(cond);
+            } else {
+                Condition cond = new Condition();
+                cond.setAttribute("to_tsvector(json_data::text)");
+                cond.setOperator("@@");
+                String[] values = {freeText};
+                cond.setValues(Arrays.asList(values));
+                conditions.add(cond);
+            }
+        }
+    }
+
+    private String getSort() {
+        ArrayList<String> sortConds = new ArrayList<>();
+        for (String s : sort) {
+            String[] splitCond = s.split(":");
+            if (splitCond.length == 2) {
+                String attribute = camelToSnake(splitCond[0]);
+                String order = splitCond[1].toUpperCase();
+                if (Arrays.asList(VALID_FIELDS).contains(attribute)
+                        && Arrays.asList(VALID_SORT_ORDER).contains(order)) {
+                    sortConds.add(attribute + " " + order);
+                }
+            }
+        }
+
+        if (sortConds.size() > 0) {
+            return " ORDER BY " + String.join(", ", sortConds);
+        }
+        return "";
+    }
+
+    private static String camelToSnake(String camel) {
+        return camel.replaceAll("\\B([A-Z])", "_$1").toLowerCase();
+    }
+}

--- a/persistence/postgres-persistence/src/main/resources/db/migration_postgres/V8__indexing.sql
+++ b/persistence/postgres-persistence/src/main/resources/db/migration_postgres/V8__indexing.sql
@@ -1,0 +1,47 @@
+CREATE TABLE workflow_index (
+  workflow_id VARCHAR(255) NOT NULL,
+  correlation_id VARCHAR(128) NULL,
+  workflow_type VARCHAR(128) NOT NULL,
+  start_time TIMESTAMP WITH TIME ZONE NOT NULL,
+  status VARCHAR(32) NOT NULL,
+  json_data JSONB NOT NULL,
+  PRIMARY KEY (workflow_id)
+);
+
+CREATE INDEX workflow_index_correlation_id_idx ON workflow_index (correlation_id);
+CREATE INDEX workflow_index_workflow_type_idx ON workflow_index (workflow_type);
+CREATE INDEX workflow_index_start_time_idx ON workflow_index (start_time);
+CREATE INDEX workflow_index_status_idx ON workflow_index (status);
+CREATE INDEX workflow_index_json_data_json_idx ON workflow_index USING gin(jsonb_to_tsvector('english', json_data, '["all"]'));
+CREATE INDEX workflow_index_json_data_text_idx ON workflow_index USING gin(to_tsvector('english', json_data::text));
+
+CREATE TABLE task_index (
+  task_id VARCHAR(255) NOT NULL,
+  task_type VARCHAR(32) NOT NULL,
+  task_def_name VARCHAR(255) NOT NULL,
+  status VARCHAR(32) NOT NULL,
+  start_time TIMESTAMP WITH TIME ZONE NOT NULL,
+  update_time TIMESTAMP WITH TIME ZONE NOT NULL,
+  workflow_type VARCHAR(128) NOT NULL,
+  json_data JSONB NOT NULL,
+  PRIMARY KEY (task_id)
+);
+
+CREATE INDEX task_index_task_id_idx ON task_index (task_id);
+CREATE INDEX task_index_task_type_idx ON task_index (task_type);
+CREATE INDEX task_index_task_def_name_idx ON task_index (task_def_name);
+CREATE INDEX task_index_status_idx ON task_index (status);
+CREATE INDEX task_index_update_time_idx ON task_index (update_time);
+CREATE INDEX task_index_workflow_type_idx ON task_index (workflow_type);
+CREATE INDEX task_index_json_data_json_idx ON workflow_index USING gin(jsonb_to_tsvector('english', json_data, '["all"]'));
+CREATE INDEX task_index_json_data_text_idx ON workflow_index USING gin(to_tsvector('english', json_data::text));
+
+CREATE TABLE task_execution_logs (
+    log_id SERIAL,
+    task_id varchar(255) NOT NULL,
+    log TEXT NOT NULL,
+    created_time TIMESTAMP WITH TIME ZONE NOT NULL,
+    PRIMARY KEY (log_id)
+);
+
+CREATE INDEX task_execution_logs_task_id_idx ON task_execution_logs (task_id);

--- a/persistence/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresIndexDAOTest.java
+++ b/persistence/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresIndexDAOTest.java
@@ -1,0 +1,396 @@
+/*
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.postgres.dao;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+import java.util.*;
+
+import javax.sql.DataSource;
+
+import org.flywaydb.core.Flyway;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.TaskExecLog;
+import com.netflix.conductor.common.run.SearchResult;
+import com.netflix.conductor.common.run.TaskSummary;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.common.run.WorkflowSummary;
+import com.netflix.conductor.postgres.config.PostgresConfiguration;
+import com.netflix.conductor.postgres.util.Query;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.Assert.*;
+
+@ContextConfiguration(
+        classes = {
+            TestObjectMapperConfiguration.class,
+            PostgresConfiguration.class,
+            FlywayAutoConfiguration.class
+        })
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class PostgresIndexDAOTest {
+
+    @Autowired private PostgresIndexDAO indexDAO;
+
+    @Autowired private ObjectMapper objectMapper;
+
+    @Qualifier("dataSource")
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired Flyway flyway;
+
+    // clean the database between tests.
+    @Before
+    public void before() {
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    private WorkflowSummary getMockWorkflowSummary(String id) {
+        WorkflowSummary wfs = new WorkflowSummary();
+        wfs.setWorkflowId(id);
+        wfs.setCorrelationId("correlation-id");
+        wfs.setWorkflowType("workflow-type");
+        wfs.setStartTime("2023-02-07T08:42:45Z");
+        wfs.setStatus(Workflow.WorkflowStatus.COMPLETED);
+        return wfs;
+    }
+
+    private TaskSummary getMockTaskSummary(String taskId) {
+        TaskSummary ts = new TaskSummary();
+        ts.setTaskId(taskId);
+        ts.setTaskType("task-type");
+        ts.setTaskDefName("task-def-name");
+        ts.setStatus(Task.Status.COMPLETED);
+        ts.setStartTime("2023-02-07T09:41:45Z");
+        ts.setUpdateTime("2023-02-07T09:42:45Z");
+        ts.setWorkflowType("workflow-type");
+        return ts;
+    }
+
+    private TaskExecLog getMockTaskExecutionLog(long createdTime, String log) {
+        TaskExecLog tse = new TaskExecLog();
+        tse.setTaskId("task-id");
+        tse.setLog(log);
+        tse.setCreatedTime(createdTime);
+        return tse;
+    }
+
+    private void compareWorkflowSummary(WorkflowSummary wfs) throws SQLException {
+        List<Map<String, Object>> result =
+                queryDb(
+                        String.format(
+                                "SELECT * FROM workflow_index WHERE workflow_id = '%s'",
+                                wfs.getWorkflowId()));
+        assertEquals("Wrong number of rows returned", 1, result.size());
+        assertEquals(
+                "Workflow id does not match",
+                wfs.getWorkflowId(),
+                result.get(0).get("workflow_id"));
+        assertEquals(
+                "Correlation id does not match",
+                wfs.getCorrelationId(),
+                result.get(0).get("correlation_id"));
+        assertEquals(
+                "Workflow type does not match",
+                wfs.getWorkflowType(),
+                result.get(0).get("workflow_type"));
+        TemporalAccessor ta = DateTimeFormatter.ISO_INSTANT.parse(wfs.getStartTime());
+        Timestamp startTime = Timestamp.from(Instant.from(ta));
+        assertEquals("Start time does not match", startTime, result.get(0).get("start_time"));
+        assertEquals(
+                "Status does not match", wfs.getStatus().toString(), result.get(0).get("status"));
+    }
+
+    private List<Map<String, Object>> queryDb(String query) throws SQLException {
+        try (Connection c = dataSource.getConnection()) {
+            try (Query q = new Query(objectMapper, c, query)) {
+                return q.executeAndFetchMap();
+            }
+        }
+    }
+
+    private void compareTaskSummary(TaskSummary ts) throws SQLException {
+        List<Map<String, Object>> result =
+                queryDb(
+                        String.format(
+                                "SELECT * FROM task_index WHERE task_id = '%s'", ts.getTaskId()));
+        assertEquals("Wrong number of rows returned", 1, result.size());
+        assertEquals("Task id does not match", ts.getTaskId(), result.get(0).get("task_id"));
+        assertEquals("Task type does not match", ts.getTaskType(), result.get(0).get("task_type"));
+        assertEquals(
+                "Task def name does not match",
+                ts.getTaskDefName(),
+                result.get(0).get("task_def_name"));
+        TemporalAccessor startTa = DateTimeFormatter.ISO_INSTANT.parse(ts.getStartTime());
+        Timestamp startTime = Timestamp.from(Instant.from(startTa));
+        assertEquals("Start time does not match", startTime, result.get(0).get("start_time"));
+        TemporalAccessor updateTa = DateTimeFormatter.ISO_INSTANT.parse(ts.getUpdateTime());
+        Timestamp updateTime = Timestamp.from(Instant.from(updateTa));
+        assertEquals("Update time does not match", updateTime, result.get(0).get("update_time"));
+        assertEquals(
+                "Status does not match", ts.getStatus().toString(), result.get(0).get("status"));
+        assertEquals(
+                "Workflow type does not match",
+                ts.getWorkflowType().toString(),
+                result.get(0).get("workflow_type"));
+    }
+
+    @Test
+    public void testIndexNewWorkflow() throws SQLException {
+        WorkflowSummary wfs = getMockWorkflowSummary("workflow-id");
+
+        indexDAO.indexWorkflow(wfs);
+
+        compareWorkflowSummary(wfs);
+    }
+
+    @Test
+    public void testIndexExistingWorkflow() throws SQLException {
+        WorkflowSummary wfs = getMockWorkflowSummary("workflow-id");
+
+        indexDAO.indexWorkflow(wfs);
+
+        compareWorkflowSummary(wfs);
+
+        wfs.setStatus(Workflow.WorkflowStatus.FAILED);
+
+        indexDAO.indexWorkflow(wfs);
+
+        compareWorkflowSummary(wfs);
+    }
+
+    @Test
+    public void testIndexNewTask() throws SQLException {
+        TaskSummary ts = getMockTaskSummary("task-id");
+
+        indexDAO.indexTask(ts);
+
+        compareTaskSummary(ts);
+    }
+
+    @Test
+    public void testIndexExistingTask() throws SQLException {
+        TaskSummary ts = getMockTaskSummary("task-id");
+
+        indexDAO.indexTask(ts);
+
+        compareTaskSummary(ts);
+
+        ts.setStatus(Task.Status.FAILED);
+
+        indexDAO.indexTask(ts);
+
+        compareTaskSummary(ts);
+    }
+
+    @Test
+    public void testAddTaskExecutionLogs() throws SQLException {
+        List<TaskExecLog> logs = new ArrayList<>();
+        logs.add(getMockTaskExecutionLog(1675845986000L, "Log 1"));
+        logs.add(getMockTaskExecutionLog(1675845987000L, "Log 2"));
+
+        indexDAO.addTaskExecutionLogs(logs);
+
+        List<Map<String, Object>> records =
+                queryDb("SELECT * FROM task_execution_logs ORDER BY created_time ASC");
+        assertEquals("Wrong number of logs returned", 2, records.size());
+        assertEquals(logs.get(0).getLog(), records.get(0).get("log"));
+        assertEquals(new Date(1675845986000L), records.get(0).get("created_time"));
+        assertEquals(logs.get(1).getLog(), records.get(1).get("log"));
+        assertEquals(new Date(1675845987000L), records.get(1).get("created_time"));
+    }
+
+    @Test
+    public void testSearchWorkflowSummary() {
+        WorkflowSummary wfs = getMockWorkflowSummary("workflow-id");
+
+        indexDAO.indexWorkflow(wfs);
+
+        String query = String.format("workflowId=\"%s\"", wfs.getWorkflowId());
+        SearchResult<WorkflowSummary> results =
+                indexDAO.searchWorkflowSummary(query, "*", 0, 15, new ArrayList());
+        assertEquals("No results returned", 1, results.getResults().size());
+        assertEquals(
+                "Wrong workflow returned",
+                wfs.getWorkflowId(),
+                results.getResults().get(0).getWorkflowId());
+    }
+
+    @Test
+    public void testFullTextSearchWorkflowSummary() {
+        WorkflowSummary wfs = getMockWorkflowSummary("workflow-id");
+
+        indexDAO.indexWorkflow(wfs);
+
+        String freeText = "notworkflow-id";
+        SearchResult<WorkflowSummary> results =
+                indexDAO.searchWorkflowSummary("", freeText, 0, 15, new ArrayList());
+        assertEquals("Wrong number of results returned", 0, results.getResults().size());
+
+        freeText = "workflow-id";
+        results = indexDAO.searchWorkflowSummary("", freeText, 0, 15, new ArrayList());
+        assertEquals("No results returned", 1, results.getResults().size());
+        assertEquals(
+                "Wrong workflow returned",
+                wfs.getWorkflowId(),
+                results.getResults().get(0).getWorkflowId());
+    }
+
+    @Test
+    public void testJsonSearchWorkflowSummary() {
+        WorkflowSummary wfs = getMockWorkflowSummary("workflow-id");
+        wfs.setVersion(3);
+
+        indexDAO.indexWorkflow(wfs);
+
+        String freeText = "{\"correlationId\":\"not-the-id\"}";
+        SearchResult<WorkflowSummary> results =
+                indexDAO.searchWorkflowSummary("", freeText, 0, 15, new ArrayList());
+        assertEquals("Wrong number of results returned", 0, results.getResults().size());
+
+        freeText = "{\"correlationId\":\"correlation-id\", \"version\":3}";
+        results = indexDAO.searchWorkflowSummary("", freeText, 0, 15, new ArrayList());
+        assertEquals("No results returned", 1, results.getResults().size());
+        assertEquals(
+                "Wrong workflow returned",
+                wfs.getWorkflowId(),
+                results.getResults().get(0).getWorkflowId());
+    }
+
+    @Test
+    public void testSearchWorkflowSummaryPagination() {
+        for (int i = 0; i < 5; i++) {
+            WorkflowSummary wfs = getMockWorkflowSummary("workflow-id-" + i);
+            indexDAO.indexWorkflow(wfs);
+        }
+
+        List<String> orderBy = Arrays.asList(new String[] {"workflowId:DESC"});
+        SearchResult<WorkflowSummary> results =
+                indexDAO.searchWorkflowSummary("", "*", 0, 2, orderBy);
+        assertEquals("Wrong totalHits returned", 3, results.getTotalHits());
+        assertEquals("Wrong number of results returned", 2, results.getResults().size());
+        assertEquals(
+                "Results returned in wrong order",
+                "workflow-id-4",
+                results.getResults().get(0).getWorkflowId());
+        assertEquals(
+                "Results returned in wrong order",
+                "workflow-id-3",
+                results.getResults().get(1).getWorkflowId());
+        results = indexDAO.searchWorkflowSummary("", "*", 2, 2, orderBy);
+        assertEquals("Wrong totalHits returned", 5, results.getTotalHits());
+        assertEquals("Wrong number of results returned", 2, results.getResults().size());
+        assertEquals(
+                "Results returned in wrong order",
+                "workflow-id-2",
+                results.getResults().get(0).getWorkflowId());
+        assertEquals(
+                "Results returned in wrong order",
+                "workflow-id-1",
+                results.getResults().get(1).getWorkflowId());
+        results = indexDAO.searchWorkflowSummary("", "*", 4, 2, orderBy);
+        assertEquals("Wrong totalHits returned", 5, results.getTotalHits());
+        assertEquals("Wrong number of results returned", 1, results.getResults().size());
+        assertEquals(
+                "Results returned in wrong order",
+                "workflow-id-0",
+                results.getResults().get(0).getWorkflowId());
+    }
+
+    @Test
+    public void testSearchTaskSummary() {
+        TaskSummary ts = getMockTaskSummary("task-id");
+
+        indexDAO.indexTask(ts);
+
+        String query = String.format("taskId=\"%s\"", ts.getTaskId());
+        SearchResult<TaskSummary> results =
+                indexDAO.searchTaskSummary(query, "*", 0, 15, new ArrayList());
+        assertEquals("No results returned", 1, results.getResults().size());
+        assertEquals(
+                "Wrong task returned", ts.getTaskId(), results.getResults().get(0).getTaskId());
+    }
+
+    @Test
+    public void testSearchTaskSummaryPagination() {
+        for (int i = 0; i < 5; i++) {
+            TaskSummary ts = getMockTaskSummary("task-id-" + i);
+            indexDAO.indexTask(ts);
+        }
+
+        List<String> orderBy = Arrays.asList(new String[] {"taskId:DESC"});
+        SearchResult<TaskSummary> results = indexDAO.searchTaskSummary("", "*", 0, 2, orderBy);
+        assertEquals("Wrong totalHits returned", 3, results.getTotalHits());
+        assertEquals("Wrong number of results returned", 2, results.getResults().size());
+        assertEquals(
+                "Results returned in wrong order",
+                "task-id-4",
+                results.getResults().get(0).getTaskId());
+        assertEquals(
+                "Results returned in wrong order",
+                "task-id-3",
+                results.getResults().get(1).getTaskId());
+        results = indexDAO.searchTaskSummary("", "*", 2, 2, orderBy);
+        assertEquals("Wrong totalHits returned", 5, results.getTotalHits());
+        assertEquals("Wrong number of results returned", 2, results.getResults().size());
+        assertEquals(
+                "Results returned in wrong order",
+                "task-id-2",
+                results.getResults().get(0).getTaskId());
+        assertEquals(
+                "Results returned in wrong order",
+                "task-id-1",
+                results.getResults().get(1).getTaskId());
+        results = indexDAO.searchTaskSummary("", "*", 4, 2, orderBy);
+        assertEquals("Wrong totalHits returned", 5, results.getTotalHits());
+        assertEquals("Wrong number of results returned", 1, results.getResults().size());
+        assertEquals(
+                "Results returned in wrong order",
+                "task-id-0",
+                results.getResults().get(0).getTaskId());
+    }
+
+    @Test
+    public void testGetTaskExecutionLogs() throws SQLException {
+        List<TaskExecLog> logs = new ArrayList<>();
+        logs.add(getMockTaskExecutionLog(new Date(1675845986000L).getTime(), "Log 1"));
+        logs.add(getMockTaskExecutionLog(new Date(1675845987000L).getTime(), "Log 2"));
+
+        indexDAO.addTaskExecutionLogs(logs);
+
+        List<TaskExecLog> records = indexDAO.getTaskExecutionLogs(logs.get(0).getTaskId());
+        assertEquals("Wrong number of logs returned", 2, records.size());
+        assertEquals(logs.get(0).getLog(), records.get(0).getLog());
+        assertEquals(logs.get(0).getCreatedTime(), 1675845986000L);
+        assertEquals(logs.get(1).getLog(), records.get(1).getLog());
+        assertEquals(logs.get(1).getCreatedTime(), 1675845987000L);
+    }
+}

--- a/persistence/postgres-persistence/src/test/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilderTest.java
+++ b/persistence/postgres-persistence/src/test/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilderTest.java
@@ -1,0 +1,285 @@
+/*
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.postgres.util;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class PostgresIndexQueryBuilderTest {
+    @Test
+    void shouldGenerateQueryForEmptyString() throws SQLException {
+        String inputQuery = "";
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+        String generatedQuery = builder.getQuery();
+        assertEquals("SELECT json_data::TEXT FROM table_name LIMIT ? OFFSET ?", generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldGenerateQueryForNull() throws SQLException {
+        String inputQuery = null;
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+        String generatedQuery = builder.getQuery();
+        assertEquals("SELECT json_data::TEXT FROM table_name LIMIT ? OFFSET ?", generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldGenerateQueryForWorkflowId() throws SQLException {
+        String inputQuery = "workflowId=\"abc123\"";
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data::TEXT FROM table_name WHERE workflow_id = ? LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("abc123");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldGenerateQueryForMultipleInClause() throws SQLException {
+        String inputQuery = "status IN (COMPLETED,RUNNING)";
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data::TEXT FROM table_name WHERE status = ANY(?) LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter(new ArrayList<>(List.of("COMPLETED", "RUNNING")));
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldGenerateQueryForSingleInClause() throws SQLException {
+        String inputQuery = "status IN (COMPLETED)";
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data::TEXT FROM table_name WHERE status = ? LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("COMPLETED");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldGenerateQueryForStartTimeGt() throws SQLException {
+        String inputQuery = "startTime>1675702498000";
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data::TEXT FROM table_name WHERE start_time > ?::TIMESTAMPTZ LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("2023-02-06T16:54:58Z");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldGenerateQueryForStartTimeLt() throws SQLException {
+        String inputQuery = "startTime<1675702498000";
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data::TEXT FROM table_name WHERE start_time < ?::TIMESTAMPTZ LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("2023-02-06T16:54:58Z");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldGenerateQueryForUpdateTimeGt() throws SQLException {
+        String inputQuery = "updateTime>1675702498000";
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data::TEXT FROM table_name WHERE update_time > ?::TIMESTAMPTZ LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("2023-02-06T16:54:58Z");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldGenerateQueryForUpdateTimeLt() throws SQLException {
+        String inputQuery = "updateTime<1675702498000";
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data::TEXT FROM table_name WHERE update_time < ?::TIMESTAMPTZ LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("2023-02-06T16:54:58Z");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldGenerateQueryForMultipleConditions() throws SQLException {
+        String inputQuery =
+                "workflowId=\"abc123\" AND workflowType IN (one,two) AND status IN (COMPLETED,RUNNING) AND startTime>1675701498000 AND startTime<1675702498000";
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data::TEXT FROM table_name WHERE start_time < ?::TIMESTAMPTZ AND start_time > ?::TIMESTAMPTZ AND status = ANY(?) AND workflow_id = ? AND workflow_type = ANY(?) LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("2023-02-06T16:54:58Z");
+        inOrder.verify(mockQuery).addParameter("2023-02-06T16:38:18Z");
+        inOrder.verify(mockQuery).addParameter(new ArrayList<>(List.of("COMPLETED", "RUNNING")));
+        inOrder.verify(mockQuery).addParameter("abc123");
+        inOrder.verify(mockQuery).addParameter(new ArrayList<>(List.of("one", "two")));
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldGenerateOrderBy() throws SQLException {
+        String inputQuery = "updateTime<1675702498000";
+        String[] query = {"updateTime:DESC"};
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, Arrays.asList(query));
+        String expectedQuery =
+                "SELECT json_data::TEXT FROM table_name WHERE update_time < ?::TIMESTAMPTZ ORDER BY update_time DESC LIMIT ? OFFSET ?";
+        assertEquals(expectedQuery, builder.getQuery());
+    }
+
+    @Test
+    void shouldGenerateOrderByMultiple() throws SQLException {
+        String inputQuery = "updateTime<1675702498000";
+        String[] query = {"updateTime:DESC", "correlationId:ASC"};
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, Arrays.asList(query));
+        String expectedQuery =
+                "SELECT json_data::TEXT FROM table_name WHERE update_time < ?::TIMESTAMPTZ ORDER BY update_time DESC, correlation_id ASC LIMIT ? OFFSET ?";
+        assertEquals(expectedQuery, builder.getQuery());
+    }
+
+    @Test
+    void shouldNotAllowInvalidColumns() throws SQLException {
+        String inputQuery = "sqlInjection<1675702498000";
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+        String expectedQuery = "SELECT json_data::TEXT FROM table_name LIMIT ? OFFSET ?";
+        assertEquals(expectedQuery, builder.getQuery());
+    }
+
+    @Test
+    void shouldNotAllowInvalidSortColumn() throws SQLException {
+        String inputQuery = "updateTime<1675702498000";
+        String[] query = {"sqlInjection:DESC"};
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, Arrays.asList(query));
+        String expectedQuery =
+                "SELECT json_data::TEXT FROM table_name WHERE update_time < ?::TIMESTAMPTZ LIMIT ? OFFSET ?";
+        assertEquals(expectedQuery, builder.getQuery());
+    }
+
+    @Test
+    void shouldAllowFullTextSearch() throws SQLException {
+        String freeText = "correlation-id";
+        String[] query = {"sqlInjection:DESC"};
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", "", freeText, 0, 15, Arrays.asList(query));
+        String expectedQuery =
+                "SELECT json_data::TEXT FROM table_name WHERE to_tsvector(json_data::text) @@ to_tsquery(?) LIMIT ? OFFSET ?";
+        assertEquals(expectedQuery, builder.getQuery());
+    }
+
+    @Test
+    void shouldAllowJsonSearch() throws SQLException {
+        String freeText = "{\"correlationId\":\"not-the-id\"}";
+        String[] query = {"sqlInjection:DESC"};
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", "", freeText, 0, 15, Arrays.asList(query));
+        String expectedQuery =
+                "SELECT json_data::TEXT FROM table_name WHERE json_data @> ?::JSONB LIMIT ? OFFSET ?";
+        assertEquals(expectedQuery, builder.getQuery());
+    }
+}

--- a/test-util/src/test/resources/application-integrationtest.properties
+++ b/test-util/src/test/resources/application-integrationtest.properties
@@ -1,7 +1,8 @@
 conductor.db.type=memory
 conductor.workflow-execution-lock.type=local_only
 conductor.external-payload-storage.type=dummy
-conductor.indexing.enabled=false
+conductor.indexing.enabled=true
+conductor.indexing.type=postgres
 
 conductor.app.stack=test
 conductor.app.appId=conductor


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
This PR provides a Postgres IndexDAO so that when running purely on Postgres (without ElasticSearch) all of the executions and tasks can still be searched for in the UI. It uses columns for searching on specific fields and also enables full text (strucutred and unstructured) searching of the underlying JSON document.
