### PR TITLE
Fix bug with ES Index and Postgres Index DAOs colliding

### DIFF
--- a/index/es7-persistence/src/main/java/com/netflix/conductor/es7/config/ElasticSearchV7Configuration.java
+++ b/index/es7-persistence/src/main/java/com/netflix/conductor/es7/config/ElasticSearchV7Configuration.java
@@ -28,6 +28,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
@@ -78,6 +79,7 @@ public class ElasticSearchV7Configuration {
         return builder;
     }
 
+    @Primary // If you are including this project, it's assumed you want ES to be your indexing mechanism
     @Bean
     public IndexDAO es7IndexDAO(
             RestClientBuilder restClientBuilder,


### PR DESCRIPTION
The addition of Postgres as an IndexDAO made it so that if you use Conductor core as your deployment mechanism, and you use Postgres and ES7, there is a collision now. The server fails to start because there are 2 IndexDAOs provided. There is a Configuration condition that does not appear to be working either.

But, this makes the correct assumption that if you're including ES7, then you intend to use ES7 as your indexing mechanism. 

CC @bjpirt 

Pull Request type
----

- [ X ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):
