### PR TITLE
Adding support for disabling automatic execution of flyway migrations

### DIFF
--- a/persistence/README.md
+++ b/persistence/README.md
@@ -36,6 +36,9 @@ spring.datasource.username=
 spring.datasource.password=
 spring.datasource.hikari.maximum-pool-size=
 spring.datasource.hikari.auto-commit=
+
+#Use spring flyway property to enable or disable flyway migrations
+spring.flyway.enabled=
 ```
 
 ### Postgres
@@ -52,6 +55,9 @@ spring.datasource.username=
 spring.datasource.password=
 spring.datasource.hikari.maximum-pool-size=
 spring.datasource.hikari.auto-commit=
+
+#Use spring flyway property to enable or disable flyway migrations
+spring.flyway.enabled=
 ```
 
 Additionally, the postgres module includes the ability to index your workflow and task executions and to store task execution logs in Postgres without requiring ElasticSearch.

--- a/persistence/mysql-persistence/src/main/java/com/netflix/conductor/mysql/config/MySQLConfiguration.java
+++ b/persistence/mysql-persistence/src/main/java/com/netflix/conductor/mysql/config/MySQLConfiguration.java
@@ -39,9 +39,7 @@ import static com.mysql.cj.exceptions.MysqlErrorNumbers.ER_LOCK_DEADLOCK;
 
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(MySQLProperties.class)
-@ConditionalOnProperty(
-        value = {"spring.flyway.enabled", "conductor.db.type"},
-        havingValue = "true,mysql")
+@ConditionalOnProperty(name = "conductor.db.type", havingValue = "mysql")
 // Import the DataSourceAutoConfiguration when mysql database is selected.
 // By default the datasource configuration is excluded in the main module.
 @Import(DataSourceAutoConfiguration.class)

--- a/persistence/mysql-persistence/src/main/java/com/netflix/conductor/mysql/config/MySQLConfiguration.java
+++ b/persistence/mysql-persistence/src/main/java/com/netflix/conductor/mysql/config/MySQLConfiguration.java
@@ -39,7 +39,9 @@ import static com.mysql.cj.exceptions.MysqlErrorNumbers.ER_LOCK_DEADLOCK;
 
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(MySQLProperties.class)
-@ConditionalOnProperty(name = "conductor.db.type", havingValue = "mysql")
+@ConditionalOnProperty(
+        value = {"spring.flyway.enabled", "conductor.db.type"},
+        havingValue = "true,mysql")
 // Import the DataSourceAutoConfiguration when mysql database is selected.
 // By default the datasource configuration is excluded in the main module.
 @Import(DataSourceAutoConfiguration.class)

--- a/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
+++ b/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
@@ -37,7 +37,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(PostgresProperties.class)
-@ConditionalOnProperty(name = "conductor.db.type", havingValue = "postgres")
+@ConditionalOnProperty(
+        value = {"spring.flyway.enabled", "conductor.db.type"},
+        havingValue = "true,postgres")
 // Import the DataSourceAutoConfiguration when postgres database is selected.
 // By default, the datasource configuration is excluded in the main module.
 @Import(DataSourceAutoConfiguration.class)

--- a/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
+++ b/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
@@ -37,9 +37,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(PostgresProperties.class)
-@ConditionalOnProperty(
-        value = {"spring.flyway.enabled", "conductor.db.type"},
-        havingValue = "true,postgres")
+@ConditionalOnProperty(name = "conductor.db.type", havingValue = "postgres")
 // Import the DataSourceAutoConfiguration when postgres database is selected.
 // By default, the datasource configuration is excluded in the main module.
 @Import(DataSourceAutoConfiguration.class)
@@ -54,6 +52,7 @@ public class PostgresConfiguration {
         this.properties = properties;
     }
 
+    @ConditionalOnProperty(name = "spring.flyway.enabled", havingValue = "true")
     @Bean(initMethod = "migrate")
     @PostConstruct
     public Flyway flywayForPrimaryDb() {
@@ -66,7 +65,7 @@ public class PostgresConfiguration {
     }
 
     @Bean
-    @DependsOn({"flywayForPrimaryDb"})
+    @DependsOn({"flyway", "flywayInitializer"})
     public PostgresMetadataDAO postgresMetadataDAO(
             @Qualifier("postgresRetryTemplate") RetryTemplate retryTemplate,
             ObjectMapper objectMapper,
@@ -75,7 +74,7 @@ public class PostgresConfiguration {
     }
 
     @Bean
-    @DependsOn({"flywayForPrimaryDb"})
+    @DependsOn({"flyway", "flywayInitializer"})
     public PostgresExecutionDAO postgresExecutionDAO(
             @Qualifier("postgresRetryTemplate") RetryTemplate retryTemplate,
             ObjectMapper objectMapper) {
@@ -83,7 +82,7 @@ public class PostgresConfiguration {
     }
 
     @Bean
-    @DependsOn({"flywayForPrimaryDb"})
+    @DependsOn({"flyway", "flywayInitializer"})
     public PostgresQueueDAO postgresQueueDAO(
             @Qualifier("postgresRetryTemplate") RetryTemplate retryTemplate,
             ObjectMapper objectMapper) {
@@ -91,7 +90,7 @@ public class PostgresConfiguration {
     }
 
     @Bean
-    @DependsOn({"flywayForPrimaryDb"})
+    @DependsOn({"flyway", "flywayInitializer"})
     @ConditionalOnProperty(name = "conductor.indexing.type", havingValue = "postgres")
     public PostgresIndexDAO postgresIndexDAO(
             @Qualifier("postgresRetryTemplate") RetryTemplate retryTemplate,


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

This pull request adds the `spring.flyway.enabled` on @ConditionalOnProperty annotation to ensure that the Flyway bean is initialized only if Spring's Flyway is enabled.

It is important because, in some cases, it may be necessary to disable automatic execution of Flyway configurations.

By using the `@ConditionalOnProperty` annotation with the spring.flyway.enabled property, this pull request allows for the option of disabling Flyway execution. When spring.flyway.enabled is set to false, Flyway will not be executed.

This change provides greater flexibility and control over the execution of Flyway configurations, allowing users to easily turn Flyway on or off as needed.
