### PR TITLE
Support for binding multiple queues to the same exchanges

### DIFF
--- a/event-queue/amqp/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueue.java
+++ b/event-queue/amqp/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueue.java
@@ -766,7 +766,7 @@ public class AMQPObservableQueue implements ObservableQueue {
                 /*
                  * Create queue if not present based on the settings provided in the queue URI
                  * or configuration properties. Sample URI format:
-                 * amqp-exchange:myExchange?exchangeType=topic&routingKey=myRoutingKey&exclusive
+                 * amqp_exchange:myExchange?bindQueueName=myQueue&exchangeType=topic&routingKey=myRoutingKey&exclusive
                  * =false&autoDelete=false&durable=true Default settings if not provided in the
                  * queue URI or properties: isDurable: true, autoDelete: false, isExclusive:
                  * false The same settings are currently used during creation of exchange as
@@ -776,7 +776,7 @@ public class AMQPObservableQueue implements ObservableQueue {
                 final AMQP.Queue.DeclareOk declareOk =
                         getOrCreateQueue(
                                 ConnectionType.SUBSCRIBER,
-                                String.format("bound_to_%s", settings.getQueueOrExchangeName()),
+                                settings.getExchangeBoundQueueName(),
                                 settings.isDurable(),
                                 settings.isExclusive(),
                                 settings.autoDelete(),
@@ -816,7 +816,7 @@ public class AMQPObservableQueue implements ObservableQueue {
                 /*
                  * Create queue if not present based on the settings provided in the queue URI
                  * or configuration properties. Sample URI format:
-                 * amqp-exchange:myExchange?exchangeType=topic&routingKey=myRoutingKey&exclusive
+                 * amqp_exchange:myExchange?bindQueueName=myQueue&exchangeType=topic&routingKey=myRoutingKey&exclusive
                  * =false&autoDelete=false&durable=true Default settings if not provided in the
                  * queue URI or properties: isDurable: true, autoDelete: false, isExclusive:
                  * false The same settings are currently used during creation of exchange as
@@ -826,7 +826,7 @@ public class AMQPObservableQueue implements ObservableQueue {
                 final AMQP.Queue.DeclareOk declareOk =
                         getOrCreateQueue(
                                 ConnectionType.SUBSCRIBER,
-                                String.format("bound_to_%s", settings.getQueueOrExchangeName()),
+                                settings.getExchangeBoundQueueName(),
                                 settings.isDurable(),
                                 settings.isExclusive(),
                                 settings.autoDelete(),
@@ -835,7 +835,7 @@ public class AMQPObservableQueue implements ObservableQueue {
                 queueName = declareOk.getQueue();
                 amqpConnection
                         .getOrCreateChannel(
-                                ConnectionType.SUBSCRIBER, getSettings().getQueueOrExchangeName())
+                                ConnectionType.SUBSCRIBER, settings.getQueueOrExchangeName())
                         .queueBind(
                                 queueName,
                                 settings.getQueueOrExchangeName(),

--- a/event-queue/amqp/src/main/java/com/netflix/conductor/contribs/queue/amqp/util/AMQPConfigurations.java
+++ b/event-queue/amqp/src/main/java/com/netflix/conductor/contribs/queue/amqp/util/AMQPConfigurations.java
@@ -18,6 +18,7 @@ public enum AMQPConfigurations {
 
     // queue exchange settings
     PARAM_EXCHANGE_TYPE("exchangeType"),
+    PARAM_QUEUE_NAME("bindQueueName"),
     PARAM_ROUTING_KEY("routingKey"),
     PARAM_DELIVERY_MODE("deliveryMode"),
     PARAM_DURABLE("durable"),

--- a/event-queue/amqp/src/main/java/com/netflix/conductor/contribs/queue/amqp/util/AMQPSettings.java
+++ b/event-queue/amqp/src/main/java/com/netflix/conductor/contribs/queue/amqp/util/AMQPSettings.java
@@ -24,13 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import com.netflix.conductor.contribs.queue.amqp.config.AMQPEventQueueProperties;
 
-import static com.netflix.conductor.contribs.queue.amqp.util.AMQPConfigurations.PARAM_AUTO_DELETE;
-import static com.netflix.conductor.contribs.queue.amqp.util.AMQPConfigurations.PARAM_DELIVERY_MODE;
-import static com.netflix.conductor.contribs.queue.amqp.util.AMQPConfigurations.PARAM_DURABLE;
-import static com.netflix.conductor.contribs.queue.amqp.util.AMQPConfigurations.PARAM_EXCHANGE_TYPE;
-import static com.netflix.conductor.contribs.queue.amqp.util.AMQPConfigurations.PARAM_EXCLUSIVE;
-import static com.netflix.conductor.contribs.queue.amqp.util.AMQPConfigurations.PARAM_MAX_PRIORITY;
-import static com.netflix.conductor.contribs.queue.amqp.util.AMQPConfigurations.PARAM_ROUTING_KEY;
+import static com.netflix.conductor.contribs.queue.amqp.util.AMQPConfigurations.*;
 
 /**
  * @author Ritu Parathody
@@ -45,6 +39,7 @@ public class AMQPSettings {
     private String queueOrExchangeName;
     private String eventName;
     private String exchangeType;
+    private String exchangeBoundQueueName;
     private String queueType;
     private String routingKey;
     private final String contentEncoding;
@@ -109,6 +104,14 @@ public class AMQPSettings {
         return queueOrExchangeName;
     }
 
+    public String getExchangeBoundQueueName() {
+        if (StringUtils.isEmpty(exchangeBoundQueueName)) {
+            return String.format("bound_to_%s", queueOrExchangeName);
+        }
+        return exchangeBoundQueueName;
+    }
+
+
     public String getExchangeType() {
         return exchangeType;
     }
@@ -139,13 +142,13 @@ public class AMQPSettings {
      * <p><u>Example for queue:</u>
      *
      * <pre>
-     * amqp-queue:myQueue?deliveryMode=1&autoDelete=true&exclusive=true
+     * amqp_queue:myQueue?deliveryMode=1&autoDelete=true&exclusive=true
      * </pre>
      *
      * <u>Example for exchange:</u>
      *
      * <pre>
-     * amqp-exchange:myExchange?exchangeType=topic&routingKey=myRoutingKey&exclusive=true
+     * amqp_exchange:myExchange?bindQueueName=myQueue&exchangeType=topic&routingKey=myRoutingKey&exclusive=true
      * </pre>
      *
      * @param queueURI
@@ -178,6 +181,10 @@ public class AMQPSettings {
                                                         "The provided exchange type is empty");
                                             }
                                             exchangeType = value;
+                                        }
+                                        if (kv[0].equalsIgnoreCase(
+                                                (String.valueOf(PARAM_QUEUE_NAME)))) {
+                                            exchangeBoundQueueName = kv[1];
                                         }
                                         if (kv[0].equalsIgnoreCase(
                                                 (String.valueOf(PARAM_ROUTING_KEY)))) {
@@ -230,6 +237,7 @@ public class AMQPSettings {
                 && Objects.equals(exchangeType, other.exchangeType)
                 && exclusive == other.exclusive
                 && Objects.equals(queueOrExchangeName, other.queueOrExchangeName)
+                && Objects.equals(exchangeBoundQueueName, other.exchangeBoundQueueName)
                 && Objects.equals(queueType, other.queueType)
                 && Objects.equals(routingKey, other.routingKey)
                 && sequentialProcessing == other.sequentialProcessing;
@@ -248,6 +256,7 @@ public class AMQPSettings {
                 exchangeType,
                 exclusive,
                 queueOrExchangeName,
+                exchangeBoundQueueName,
                 queueType,
                 routingKey,
                 sequentialProcessing);
@@ -261,6 +270,8 @@ public class AMQPSettings {
                 + eventName
                 + ", exchangeType="
                 + exchangeType
+                + ", exchangeQueueName="
+                + exchangeBoundQueueName
                 + ", queueType="
                 + queueType
                 + ", routingKey="

--- a/event-queue/amqp/src/test/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueueTest.java
+++ b/event-queue/amqp/src/test/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueueTest.java
@@ -334,6 +334,15 @@ public class AMQPObservableQueueTest {
     }
 
     @Test
+    public void testGetMessagesFromExistingExchangeWithDefaultConfiguration() throws IOException, TimeoutException {
+        // Mock channel and connection
+        Channel channel = mockBaseChannel();
+        Connection connection = mockGoodConnection(channel);
+        testGetMessagesFromExchangeAndDefaultConfiguration(
+                channel, connection, true, true);
+    }
+
+    @Test
     public void testPublishMessagesToNotExistingExchangeAndDefaultConfiguration()
             throws IOException, TimeoutException {
         // Mock channel and connection
@@ -408,6 +417,7 @@ public class AMQPObservableQueueTest {
         assertEquals(name, settings.getQueueOrExchangeName());
         assertEquals(type, settings.getExchangeType());
         assertEquals(routingKey, settings.getRoutingKey());
+        assertEquals(queueName, settings.getExchangeBoundQueueName());
 
         List<GetResponse> queue = buildQueue(random, batchSize);
         channel =
@@ -493,6 +503,8 @@ public class AMQPObservableQueueTest {
                                         + name
                                         + "?exchangeType="
                                         + type
+                                        + "&bindQueueName="
+                                        + queueName
                                         + "&routingKey="
                                         + routingKey
                                         + "&deliveryMode=2"
@@ -508,6 +520,7 @@ public class AMQPObservableQueueTest {
         assertEquals(2, settings.getDeliveryMode());
         assertEquals(name, settings.getQueueOrExchangeName());
         assertEquals(type, settings.getExchangeType());
+        assertEquals(queueName, settings.getExchangeBoundQueueName());
         assertEquals(routingKey, settings.getRoutingKey());
 
         List<GetResponse> queue = buildQueue(random, batchSize);
@@ -540,6 +553,8 @@ public class AMQPObservableQueueTest {
                         + name
                         + "?exchangeType="
                         + type
+                        + "&bindQueueName="
+                        + queueName
                         + "&routingKey="
                         + routingKey
                         + "&deliveryMode=2"


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

Support for binding multiple queues to the same exchange -
Currently, Conductor support events handler to be bound to an exchange , but the problem is that the current code does not get the queue name to be bound to the exchange and it creates the queue with default name.
That means that event handlers with the same exchnage will be bound to the same queue.
In this PR, we added 'bindQueueName' param to get the queue name from the exchange uri to enable multiple event handlers to be bound to the same exchange with different queues.
