### PR TITLE
Issue#241 fix AMQPObservableQueue behaviour to return failed message…

### DIFF
--- a/event-queue/amqp/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueue.java
+++ b/event-queue/amqp/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueue.java
@@ -187,16 +187,16 @@ public class AMQPObservableQueue implements ObservableQueue {
     }
 
     public List<String> ack(List<Message> messages) {
-        final List<String> processedDeliveryTags = new ArrayList<>();
+        final List<String> failedMessages = new ArrayList<>();
         for (final Message message : messages) {
             try {
                 ackMsg(message);
-                processedDeliveryTags.add(message.getReceipt());
             } catch (final Exception e) {
                 LOGGER.error("Cannot ACK message with delivery tag {}", message.getReceipt(), e);
+                failedMessages.add(message.getReceipt());
             }
         }
-        return processedDeliveryTags;
+        return failedMessages;
     }
 
     public void ackMsg(Message message) throws Exception {

--- a/event-queue/amqp/src/test/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueueTest.java
+++ b/event-queue/amqp/src/test/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueueTest.java
@@ -334,12 +334,12 @@ public class AMQPObservableQueueTest {
     }
 
     @Test
-    public void testGetMessagesFromExistingExchangeWithDefaultConfiguration() throws IOException, TimeoutException {
+    public void testGetMessagesFromExistingExchangeWithDefaultConfiguration()
+            throws IOException, TimeoutException {
         // Mock channel and connection
         Channel channel = mockBaseChannel();
         Connection connection = mockGoodConnection(channel);
-        testGetMessagesFromExchangeAndDefaultConfiguration(
-                channel, connection, true, true);
+        testGetMessagesFromExchangeAndDefaultConfiguration(channel, connection, true, true);
     }
 
     @Test
@@ -386,8 +386,9 @@ public class AMQPObservableQueueTest {
         msg.setPayload("Payload");
         msg.setReceipt("1");
         messages.add(msg);
-        List<String> deliveredTags = observableQueue.ack(messages);
-        assertNotNull(deliveredTags);
+        List<String> failedMessages = observableQueue.ack(messages);
+        assertNotNull(failedMessages);
+        assertTrue(failedMessages.isEmpty());
     }
 
     private void testGetMessagesFromExchangeAndDefaultConfiguration(


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

Fixed `AMQPObservableQueue#ack` to correctly implement its interface definition, but returning the unsuccessfully-ack'ed messages and not the successfully ack'ed ones.

Issue #241  

Alternatives considered
----

None