### PR TITLE
Ensure that ScheduledExecutorService are cleaned-up on shutdown

### DIFF
--- a/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAO.java
+++ b/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAO.java
@@ -15,10 +15,13 @@ import java.sql.Connection;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.PreDestroy;
 import javax.sql.DataSource;
 
+import com.netflix.conductor.postgres.util.ExecutorsUtil;
 import org.springframework.retry.support.RetryTemplate;
 
 import com.netflix.conductor.common.metadata.events.EventHandler;
@@ -39,6 +42,8 @@ public class PostgresMetadataDAO extends PostgresBaseDAO implements MetadataDAO,
     private final ConcurrentHashMap<String, TaskDef> taskDefCache = new ConcurrentHashMap<>();
     private static final String CLASS_NAME = PostgresMetadataDAO.class.getSimpleName();
 
+    private final ScheduledExecutorService scheduledExecutorService;
+
     public PostgresMetadataDAO(
             RetryTemplate retryTemplate,
             ObjectMapper objectMapper,
@@ -47,12 +52,31 @@ public class PostgresMetadataDAO extends PostgresBaseDAO implements MetadataDAO,
         super(retryTemplate, objectMapper, dataSource);
 
         long cacheRefreshTime = properties.getTaskDefCacheRefreshInterval().getSeconds();
-        Executors.newSingleThreadScheduledExecutor()
-                .scheduleWithFixedDelay(
+        this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(
+                ExecutorsUtil.newNamedThreadFactory("postgres-metadata-"));
+        this.scheduledExecutorService.scheduleWithFixedDelay(
                         this::refreshTaskDefs,
                         cacheRefreshTime,
                         cacheRefreshTime,
                         TimeUnit.SECONDS);
+    }
+
+    @PreDestroy
+    public void destroy() {
+        try {
+            this.scheduledExecutorService.shutdown();
+            if (scheduledExecutorService.awaitTermination(30, TimeUnit.SECONDS)) {
+                logger.debug("tasks completed, shutting down");
+            } else {
+                logger.warn("Forcing shutdown after waiting for 30 seconds");
+                scheduledExecutorService.shutdownNow();
+            }
+        } catch (InterruptedException ie) {
+            logger.warn(
+                    "Shutdown interrupted, invoking shutdownNow on scheduledExecutorService for refreshTaskDefs", ie);
+            scheduledExecutorService.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
     }
 
     @Override

--- a/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/util/ExecutorsUtil.java
+++ b/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/util/ExecutorsUtil.java
@@ -1,0 +1,26 @@
+package com.netflix.conductor.postgres.util;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ExecutorsUtil {
+
+    private ExecutorsUtil() {}
+
+    public static ThreadFactory newNamedThreadFactory(final String threadNamePrefix) {
+        return new ThreadFactory() {
+
+            private final AtomicInteger counter = new AtomicInteger();
+
+            @SuppressWarnings("NullableProblems")
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread thread = Executors.defaultThreadFactory().newThread(r);
+                thread.setName(threadNamePrefix + counter.getAndIncrement());
+                return thread;
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
Ensure that the ScheduledExecutorService objects used by the Postgres DAOs are correctly cleaned-up on shutdown.

It is generally well-advised to ensure that any ExecutorServices that are created by an application are shutdown properly as the application exits. Otherwise any ExecutorService instances that are left running may stay alive and prevent the JVM from exiting cleanly, requiring a SIGKILL to fully shutdown the process. The Postgres DAO implementations do not do this and this PR addresses that.

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

The Postgres implementations of ExecutionDAO, MetadataDAO and QueueDAO are now uniformly retaining references to any ScheduledExecutorServices that they construct and initialize and ensure that those are cleaned up appropriately on shutdown.

The shutdown procedure itself has been modelled on the implementation in `com.netflix.conductor.es7.dao.index.ElasticSearchRestDAOV7#shutdownExecutorService`.

Alternatives considered
----

None.
