### PR TITLE
Unable to get CORE_CONDUCTOR_VERSION

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          export CORE_CONDUCTOR_VERSION=$(./gradlew conductor-workflow-event-listener:dependencies | grep conductor-core | grep ">" | tail -1 | cut -d ' ' -f4)
+          export CORE_CONDUCTOR_VERSION=$(/gradlew conductor-workflow-event-listener:dependencies | grep conductor-core | grep ">" | tail -1 | cut -d '>' -f 2 | cut -d ' ' -f 2)
           echo "Building against Conductor core version $CORE_CONDUCTOR_VERSION"
           ./gradlew build --scan -x test
       - name: Build and Publish snapshot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          export CORE_CONDUCTOR_VERSION=$(/gradlew conductor-workflow-event-listener:dependencies | grep conductor-core | grep ">" | tail -1 | cut -d '>' -f 2 | cut -d ' ' -f 2)
+          export CORE_CONDUCTOR_VERSION=$(./gradlew conductor-workflow-event-listener:dependencies | grep conductor-core | grep ">" | tail -1 | cut -d '>' -f 2 | cut -d ' ' -f 2)
           echo "Building against Conductor core version $CORE_CONDUCTOR_VERSION"
           ./gradlew build --scan -x test
       - name: Build and Publish snapshot


### PR DESCRIPTION
Fix for https://github.com/Netflix/conductor-community/issues/254

Output of command
`./gradlew conductor-workflow-event-listener:dependencies | grep conductor-core`
is
` \--- com.netflix.conductor:conductor-core:3.13.8
\--- com.netflix.conductor:conductor-core:3.13.8 (n)
\--- com.netflix.conductor:conductor-core:3.13.8
+--- com.netflix.conductor:conductor-core:3.13.8
+--- com.netflix.conductor:conductor-core:3.13.8
|    |    +--- com.netflix.conductor:conductor-core:3.13.8 (*)
|    +--- com.netflix.conductor:conductor-core:3.13.8 (*)
|    |    +--- com.netflix.conductor:conductor-core:3.13.8 (*)
|    |    +--- com.netflix.conductor:conductor-core:3.13.8 (*)
|    |    +--- com.netflix.conductor:conductor-core:3.13.8 (*)
|    |    +--- com.netflix.conductor:conductor-core:3.13.8 (*)
|    |    +--- com.netflix.conductor:conductor-core:3.13.8 (*)
|    |    +--- com.netflix.conductor:conductor-core:3.13.8 (*)
|    |    +--- com.netflix.conductor:conductor-core:3.13.8 (*)
|    |    +--- com.netflix.conductor:conductor-core:3.13.8 (*)
|    |    +--- com.netflix.conductor:conductor-core:3.13.8 (*)
|    |    +--- com.netflix.conductor:conductor-core:3.13.8 (*)
|    |    +--- com.netflix.conductor:conductor-core:3.10.7 -> 3.13.8 (*)
`

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
