### PR TITLE
support for version 8 servers

### DIFF
--- a/index/es7-persistence/README.md
+++ b/index/es7-persistence/README.md
@@ -2,6 +2,8 @@
 
 This module provides ES7 persistence when indexing workflows and tasks.
 
+NOTE: this now also works with ES8. A ES8 version is detected and the index templates are uploaded to the correct url.
+
 ### ES Breaking changes
 
 From ES6 to ES7 there were significant breaking changes which affected ES7-persistence module implementation.

--- a/index/es7-persistence/src/main/resources/template_event8.json
+++ b/index/es7-persistence/src/main/resources/template_event8.json
@@ -1,0 +1,49 @@
+{
+  "priority": 500,
+  "index_patterns": [ "*event*" ],
+  "template": {
+    "settings": {
+      "refresh_interval": "1s"
+    },
+    "mappings": {
+      "properties": {
+        "action": {
+          "type": "keyword",
+          "index": true
+        },
+        "created": {
+          "type": "long"
+        },
+        "event": {
+          "type": "keyword",
+          "index": true
+        },
+        "id": {
+          "type": "keyword",
+          "index": true
+        },
+        "messageId": {
+          "type": "keyword",
+          "index": true
+        },
+        "name": {
+          "type": "keyword",
+          "index": true
+        },
+        "output": {
+          "properties": {
+            "workflowId": {
+              "type": "keyword",
+              "index": true
+            }
+          }
+        },
+        "status": {
+          "type": "keyword",
+          "index": true
+        }
+      }
+    },
+    "aliases" : { }
+  }
+}

--- a/index/es7-persistence/src/main/resources/template_message8.json
+++ b/index/es7-persistence/src/main/resources/template_message8.json
@@ -1,0 +1,29 @@
+{
+  "priority": 501,
+  "index_patterns": [ "*message*" ],
+  "template": {
+    "settings": {
+      "refresh_interval": "1s"
+    },
+    "mappings": {
+      "properties": {
+        "created": {
+          "type": "long"
+        },
+        "messageId": {
+          "type": "keyword",
+          "index": true
+        },
+        "payload": {
+          "type": "keyword",
+          "index": true
+        },
+        "queue": {
+          "type": "keyword",
+          "index": true
+        }
+      }
+    },
+    "aliases": { }
+  }
+}

--- a/index/es7-persistence/src/main/resources/template_task_log8.json
+++ b/index/es7-persistence/src/main/resources/template_task_log8.json
@@ -1,0 +1,25 @@
+{
+  "priority": 502,
+  "index_patterns": [ "*task*log*" ],
+  "template": {
+    "settings": {
+      "refresh_interval": "1s"
+    },
+    "mappings": {
+      "properties": {
+        "createdTime": {
+          "type": "long"
+        },
+        "log": {
+          "type": "keyword",
+          "index": true
+        },
+        "taskId": {
+          "type": "keyword",
+          "index": true
+        }
+      }
+    },
+    "aliases": { }
+  }
+}


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

Added support for ES8.

_Describe the new behavior from this PR, and why it's needed_
Issue #

The ES8 API for Templates has changed.

Alternatives considered
----

Make a ES8 folder. Since the changes are 3 lines of code to the templates and the name of the index URL I didn't want to create more copy&paste code as needed.

(Maybe the build breakes on CI/CD - then I will add this PR here, too - https://github.com/Netflix/conductor-community/pull/257)